### PR TITLE
Fix order of links in the Links dropdown

### DIFF
--- a/addons/WAT/ui/links.gd
+++ b/addons/WAT/ui/links.gd
@@ -4,9 +4,9 @@ tool
 func _ready() -> void:
 	var p: PopupMenu = get_popup()
 	p.set_item_metadata(0, "https://ko-fi.com/alexanddraw")
-	p.set_item_metadata(1, "https://github.com/CodeDarigan/WAT-GDScript/issues/new")
+	p.set_item_metadata(1, "https://wat.readthedocs.io/en/latest/")
 	p.set_item_metadata(2, "https://github.com/CodeDarigan/WAT-Documentation/issues/new")
-	p.set_item_metadata(3, "https://wat.readthedocs.io/en/latest/")
+	p.set_item_metadata(3, "https://github.com/CodeDarigan/WAT-GDScript/issues/new")
 	p.connect("index_pressed", self, "_on_idx_pressed")
 
 func _on_idx_pressed(idx: int) -> void:


### PR DESCRIPTION
Sorry, I didn't notice it was this way in one of my previous PRs.