### PR TITLE
Increasing the timeout for test clients to 60s, supporting larger tests.

### DIFF
--- a/addons/WAT/network/test_server.gd
+++ b/addons/WAT/network/test_server.gd
@@ -14,6 +14,7 @@ func _ready() -> void:
 	
 func _on_network_peer_connected(id: int) -> void:
 	_peer_id = id
+	_peer.set_peer_timeout(id, 59000, 60000, 61000)
 	emit_signal("network_peer_connected")
 	
 func send_tests(testdir: Array, repeat: int, thread_count: int) -> void:

--- a/tests/unit/boolean.test.gd
+++ b/tests/unit/boolean.test.gd
@@ -16,5 +16,12 @@ func test_when_calling_asserts_is_false():
 		
 
 ## Only used sometimes
+func test_when_calling_asserts_is_true_after_10s():
+	describe("When a test runs for 10 seconds and then calls asserts.is_true(true)")
+	
+	OS.delay_msec(10000)
+	asserts.is_true(true, "Then it passes")
+
+## Only used sometimes
 #func test_intentional_failure():
 #	asserts.is_false(true)


### PR DESCRIPTION
Per default, the server disconnects very quickly if the client is not responding. If a unit test takes some seconds, the server immediately disconnects without a warning.
I run into this problem when I wrote integration tests that can take several seconds like loading and saving games, especially on a server with limited resources.

- Increased timeout to ~1 minute
- Added a test which will run for 10 seconds. Without this fix the test run will not finish with e.g. WAT -> Select Test -> Debug. Can be commented out if it works as it might be annoying to always wait for it.

Possible improvements:

- Set custom timeout in the WAT editor settings page.
- Add a warning if a client disconnects or was disconnected without an answer.