### PR TITLE
Update PluginAssetsRegistry to account for edge cases

### DIFF
--- a/addons/WAT/ui/plugin_assets_registry.gd
+++ b/addons/WAT/ui/plugin_assets_registry.gd
@@ -65,7 +65,7 @@ func get_editor_scale() -> float:
 				_cached_editor_scale = _calculate_current_editor_scale_3_0()
 		return _cached_editor_scale
 	else:
-		push_error("AssetsRegistry is not supported for version: " % Engine.get_version_info().string)
+		push_error("PluginAssetsRegistry is not supported for version: " % Engine.get_version_info().string)
 		return 1.0
 
 func _calculate_current_editor_scale_3_1() -> float:

--- a/addons/WAT/ui/plugin_assets_registry.gd
+++ b/addons/WAT/ui/plugin_assets_registry.gd
@@ -1,6 +1,7 @@
-# Repo: https://github.com/Atlinx/Godot-PluginAssetsRegistry
-
+class_name PluginAssetsRegistry
 extends Reference
+# Stores and scales editor related UI assets according to the user's editor scale.
+# Repo: https://github.com/Atlinx/Godot-PluginAssetsRegistry
 
 # Replace 'demo_plugin' with your plugin's name
 const PLUGIN_ABSOLUTE_PATH_PREFIX = "res://addons/WAT/"
@@ -51,20 +52,23 @@ func _load_scaled_font(font: Font) -> DynamicFont:
 	duplicate.size *= get_editor_scale()
 	return duplicate
 
-func get_editor_scale():
+func get_editor_scale() -> float:
 	if plugin == null:
-		return 1
-	if Engine.get_version_info().minor >= 3:
+		return 1.0
+	if Engine.get_version_info().major > 3 or (Engine.get_version_info().major == 3 and Engine.get_version_info().minor >= 3):
 		return plugin.get_editor_interface().get_editor_scale()
-	else:
+	elif Engine.get_version_info().major == 3:
 		if _cached_editor_scale == -1:
 			if Engine.get_version_info().minor >= 1:
 				_cached_editor_scale = _calculate_current_editor_scale_3_1()
 			else:
 				_cached_editor_scale = _calculate_current_editor_scale_3_0()
 		return _cached_editor_scale
+	else:
+		push_error("AssetsRegistry is not supported for version: " % Engine.get_version_info().string)
+		return 1.0
 
-func _calculate_current_editor_scale_3_1():
+func _calculate_current_editor_scale_3_1() -> float:
 	var editor_settings = plugin.get_editor_interface().get_editor_settings()
 	
 	var display_scale: int = editor_settings.get_setting("interface/editor/display_scale")
@@ -95,7 +99,7 @@ func _calculate_current_editor_scale_3_1():
 		_:
 			return custom_display_scale
 
-func _calculate_current_editor_scale_3_0():
+func _calculate_current_editor_scale_3_0() -> float:
 	var editor_settings = plugin.get_editor_interface().get_editor_settings()
 	
 	var dpi_mode = editor_settings.get_settings("interface/editor/hidpi_mode")
@@ -115,3 +119,5 @@ func _calculate_current_editor_scale_3_0():
 			return 1.5
 		4:
 			return 2.0
+		_:
+			return 1.0

--- a/addons/WAT/ui/plugin_assets_registry.gd
+++ b/addons/WAT/ui/plugin_assets_registry.gd
@@ -1,4 +1,3 @@
-class_name PluginAssetsRegistry
 extends Reference
 # Stores and scales editor related UI assets according to the user's editor scale.
 # Repo: https://github.com/Atlinx/Godot-PluginAssetsRegistry

--- a/project.godot
+++ b/project.godot
@@ -25,6 +25,11 @@ _global_script_classes=[ {
 "path": "res://Examples/Scripts/login.gd"
 }, {
 "base": "Reference",
+"class": "PluginAssetsRegistry",
+"language": "GDScript",
+"path": "res://addons/WAT/ui/plugin_assets_registry.gd"
+}, {
+"base": "Reference",
 "class": "WAT",
 "language": "GDScript",
 "path": "res://addons/WAT/namespace.gd"
@@ -58,6 +63,7 @@ _global_script_class_icons={
 "BaseLogin": "",
 "Calculator": "",
 "Login": "",
+"PluginAssetsRegistry": "",
 "WAT": "",
 "WATTest": "",
 "_watFileSystem": "",

--- a/project.godot
+++ b/project.godot
@@ -25,11 +25,6 @@ _global_script_classes=[ {
 "path": "res://Examples/Scripts/login.gd"
 }, {
 "base": "Reference",
-"class": "PluginAssetsRegistry",
-"language": "GDScript",
-"path": "res://addons/WAT/ui/plugin_assets_registry.gd"
-}, {
-"base": "Reference",
 "class": "WAT",
 "language": "GDScript",
 "path": "res://addons/WAT/namespace.gd"
@@ -63,7 +58,6 @@ _global_script_class_icons={
 "BaseLogin": "",
 "Calculator": "",
 "Login": "",
-"PluginAssetsRegistry": "",
 "WAT": "",
 "WATTest": "",
 "_watFileSystem": "",


### PR DESCRIPTION
This irons out all the possible edge cases for the plugin assets registry.

**Changes:**

- Added > 3.3 compatibility (In anticipation for Godot 4.0 and above)
- Added error for versions below 3.0
- Added static typing for methods and default return values 