### PR TITLE
Setting to disable test caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ need to close the project settings and then re-open.
     You can add string tags to your test so that you can run tests that are split across different folders in a group. You
     define which tags can be added in this setting but you do the actual adding via the GUI.
 
+- *Cache Tests*
+
+    Will avoid rescanning your test directory unless changes to them are detected. Disable this if you're using an external editor, since not all changes from an external editor are detected.
+
 - *Window Size*
 
     Defines the window size when running Tests.

--- a/addons/WAT/settings.gd
+++ b/addons/WAT/settings.gd
@@ -9,6 +9,7 @@ static func initialize() -> void:
 	_add_setting("Results_Directory", TYPE_STRING, "res://")
 	_add_setting("Test_Metadata_Directory", TYPE_STRING, "res://")
 	_add_setting("Tags", TYPE_STRING_ARRAY, PoolStringArray())
+	_add_setting("Cache_Tests", TYPE_BOOL, true)
 	_add_setting("Window_Size", TYPE_VECTOR2, Vector2(1280, 720))
 	_add_setting("Minimize_Window_When_Running_Tests", TYPE_BOOL, false)
 	_add_setting("Port", TYPE_INT, 6008)
@@ -44,6 +45,9 @@ static func window_size() -> Vector2:
 	
 static func tags() -> PoolStringArray:
 	return ProjectSettings.get_setting("WAT/Tags")
+
+static func cache_tests() -> bool:
+	return ProjectSettings.get_setting("Cache_Tests")
 	
 static func minimize_window_when_running_tests() -> bool:
 	return ProjectSettings.get_setting("WAT/Minimize_Window_When_Running_Tests")

--- a/addons/WAT/ui/gui.gd
+++ b/addons/WAT/ui/gui.gd
@@ -61,7 +61,7 @@ func setup_editor_context(plugin, build: FuncRef, goto_func: FuncRef, filesystem
 func _on_run_pressed(data = _filesystem.root) -> void:
 	Results.clear()
 	
-	if _filesystem.changed:
+	if _filesystem.changed or not Settings.cache_tests():
 		if not _filesystem.built and ClassDB.class_exists("CSharpScript") and Engine.is_editor_hint():
 			_filesystem.built = yield(_filesystem.build_function.call_func(), "completed")
 			return
@@ -85,7 +85,7 @@ func _on_run_pressed(data = _filesystem.root) -> void:
 func _on_debug_pressed(data = _filesystem.root) -> void:
 	Results.clear()
 	
-	if _filesystem.changed:
+	if _filesystem.changed or not Settings.cache_tests():
 		if not _filesystem.built and ClassDB.class_exists("CSharpScript") and Engine.is_editor_hint():
 			_filesystem.built = yield(_filesystem.build_function.call_func(), "completed")
 			return


### PR DESCRIPTION
This is a fix for https://github.com/AlexDarigan/WAT/issues/295

Adds a setting to rescan the test directory when tests are run, regardless of if filesystem/script changes are detected. I investigated the possibility of detecting changes from external editors instead, but it doesn't appear possible. The `ScriptEditor` editor [can detect changes to active script](https://docs.godotengine.org/en/stable/classes/class_scripteditor.html#class-scripteditor), but not inactive ones.

![Screenshot_2021-09-23_18-48-32](https://user-images.githubusercontent.com/3958783/134593856-8cc2f78a-7430-4aaa-962a-e58cebbe1fcd.png)
