### PR TITLE
Fix broken Select Tests dropdown whenever there is a change in the filesystem

### DIFF
--- a/addons/WAT/filesystem/filesystem.gd
+++ b/addons/WAT/filesystem/filesystem.gd
@@ -13,7 +13,7 @@ var root: TestDirectory
 var tagged: TaggedTests
 var failed: FailedTests
 var changed: bool = false setget _set_filesystem_changed
-var built: bool = false # CSharpScript
+var built: bool = false setget ,_get_filesystem_built # CSharpScript
 var build_function: FuncRef
 var index = {} # Path / Object
 
@@ -25,11 +25,15 @@ func _init(_build_function = null) -> void:
 	failed = FailedTests.new()
 
 func _set_filesystem_changed(has_changed: bool) -> void:
+	changed = has_changed
 	if has_changed:
-		changed = true
 		built = false
 
-func update(testdir: TestDirectory = _get_root()) -> void:
+func _get_filesystem_built() -> bool:
+	# If it is not Mono, automatically return true because it is irrelevant to GDScript.
+	return built and Engine.is_editor_hint() or not ClassDB.class_exists("CSharpScript")
+
+func _recursive_update(testdir: TestDirectory) -> void:
 	var dir: Directory = Directory.new()
 	var err: int = dir.open(testdir.path)
 	if err != OK:
@@ -56,7 +60,7 @@ func update(testdir: TestDirectory = _get_root()) -> void:
 			testdir.tests.append(test_script)
 			test_script.dir = testdir.path
 			index[test_script.path] = test_script
-#
+
 		relative = dir.get_next()
 		
 	dir.list_dir_end()
@@ -64,8 +68,13 @@ func update(testdir: TestDirectory = _get_root()) -> void:
 	testdir.relative_subdirs += subdirs
 	testdir.nested_subdirs += subdirs
 	for subdir in subdirs:
-		update(subdir)
+		_recursive_update(subdir)
 		testdir.nested_subdirs += subdir.nested_subdirs
+
+func update(testdir: TestDirectory = _get_root()) -> void:
+	_recursive_update(testdir)
+	# The changed attribute should be set to false after the update otherwise it is redundant.
+	changed = false
 		
 func _get_root() -> TestDirectory:
 	index = {}

--- a/addons/WAT/ui/gui.gd
+++ b/addons/WAT/ui/gui.gd
@@ -62,7 +62,7 @@ func _on_run_pressed(data = _filesystem.root) -> void:
 	Results.clear()
 	
 	if _filesystem.changed or not Settings.cache_tests():
-		if not _filesystem.built and ClassDB.class_exists("CSharpScript") and Engine.is_editor_hint():
+		if not _filesystem.built:
 			_filesystem.built = yield(_filesystem.build_function.call_func(), "completed")
 			return
 		if data == _filesystem.root:
@@ -86,7 +86,7 @@ func _on_debug_pressed(data = _filesystem.root) -> void:
 	Results.clear()
 	
 	if _filesystem.changed or not Settings.cache_tests():
-		if not _filesystem.built and ClassDB.class_exists("CSharpScript") and Engine.is_editor_hint():
+		if not _filesystem.built:
 			_filesystem.built = yield(_filesystem.build_function.call_func(), "completed")
 			return
 		if data == _filesystem.root:

--- a/addons/WAT/ui/test_menu.gd
+++ b/addons/WAT/ui/test_menu.gd
@@ -35,7 +35,7 @@ func clear() -> void:
 	_menu.queue_free()
 	
 func build():
-	if not filesystem.built and ClassDB.class_exists("CSharpScript") and Engine.is_editor_hint():
+	if not filesystem.built:
 		filesystem.built = yield(filesystem.build_function.call_func(), "completed")
 		return
 	


### PR DESCRIPTION
The ```if not _filesystem.built and ClassDB.class_exists("CSharpScript")``` check for Mono in f7d430f14a39a1affc6b46816bedac3066c26cf0 **was omitted in line 22 of [test_menu.gd](https://github.com/AlexDarigan/WAT/blob/main/addons/WAT/ui/test_menu.gd)** which caused ```build()``` to be run on GDScript where the yield will never be complete; hence, breaking the Select Tests dropdown menu.

This if-check for CSharpScript is being copied and pasted into multiple places which is the reason for such a mistake. I've consolidated it in ```filesystem.gd``` using the getter for the ```built``` attribute so that it will only check the attribute in Mono, but will always return true and be bypassed in GDScript:
```
func _get_filesystem_built() -> bool:
	# If it is not Mono, automatically return true because it is irrelevant to GDScript.
	return built and Engine.is_editor_hint() or not ClassDB.class_exists("CSharpScript")
```

The ```changed``` attribute in ```filesystem.gd``` also never sets back to false, so after the first change which sets it to true, the filesystem will **always** update even though there aren't any changes, making all ```if filesystem.changed``` checks from there on redundant.  Therefore, I separated the ```update()``` recursion in ```filesystem.gd``` line 36 in order to set ```changed``` back to false after the recursion is complete.

Resolves #300.