### PR TITLE
describe() GUI fix

### DIFF
--- a/addons/WAT/ui/results/counter.gd
+++ b/addons/WAT/ui/results/counter.gd
@@ -1,0 +1,32 @@
+extends Reference
+# Counter TreeItem component for tests passed over total executed.
+
+signal counter_changed
+
+var component: TreeItem
+var path: String
+var title: String setget set_title
+var passed: int = 0 setget set_passed
+var total: int = 0 setget set_total
+var show: bool = true
+
+func _init(_component: TreeItem) -> void:
+	component = _component
+	connect("counter_changed", self, "display")
+
+func set_passed(_passed: int) -> void:
+	passed = _passed
+	emit_signal("counter_changed")
+
+func set_total(_total: int) -> void:
+	total = _total
+	emit_signal("counter_changed")
+
+func set_title(_title: String) -> void:
+	title = _title
+	component.set_text(0, _title)
+
+# Displays (total / passed) in the component text.
+func display() -> void:
+	if show:
+		component.set_text(0, "(%s/%s) %s" % [passed, total, title])

--- a/addons/WAT/ui/results/method.gd
+++ b/addons/WAT/ui/results/method.gd
@@ -1,28 +1,22 @@
-extends Reference
+extends "res://addons/WAT/ui/results/counter.gd"
 
 const AssertionTreeItem: GDScript = preload("res://addons/WAT/ui/results/assertion.gd")
 
 var scriptpath: String
-var component: TreeItem
-var path: String
-var title: String
-var passed: int = 0
-var total: int = 0
 var name: String
 var assertions: Array = []
 
-func _init(_component: TreeItem, _title: String, _script: String) -> void:
+func _init(_component: TreeItem, _title: String, _script: String).(_component) -> void:
 	scriptpath = _script
-	component = _component
 	path = _title
 	name = _title # func name
-	title = _title.replace("test_", "").replace("_", " ")
-	_component.set_text(0, title) 
+	set_title(_title.replace("test_", "").replace("_", " "))
+	show = false # Modify if test method results should display number of assertions passed.
 	
 func add_assertion(tree: Tree, data: Dictionary):
-	total += 1
+	set_total(total + 1)
 	if data["assertion"]["success"]:
-		passed += 1
+		set_passed(passed + 1)
 	if data["assertion"]["context"] == "":
 		component.collapsed = true
 		var expected: TreeItem = tree.create_item(component)

--- a/addons/WAT/ui/results/method.gd
+++ b/addons/WAT/ui/results/method.gd
@@ -23,7 +23,6 @@ func add_assertion(tree: Tree, data: Dictionary):
 	total += 1
 	if data["assertion"]["success"]:
 		passed += 1
-	component.set_text(0, "%s" % title)
 	if data["assertion"]["context"] == "":
 		component.collapsed = true
 		var expected: TreeItem = tree.create_item(component)

--- a/addons/WAT/ui/results/script.gd
+++ b/addons/WAT/ui/results/script.gd
@@ -1,29 +1,21 @@
-extends Reference
+extends "res://addons/WAT/ui/results/counter.gd"
 
 const MethodTreeItem: GDScript = preload("res://addons/WAT/ui/results/method.gd")
-var component: TreeItem
-var path: String
-var title: String
+
 var methods: Dictionary = {}
 var method_names: PoolStringArray
-var total: int = 0
-var passed: int = 0
 
-func _init(_component: TreeItem, data: Dictionary) -> void:
-	component = _component
-	title = data["name"] if data["title"] == "" else data["title"]
+func _init(_component: TreeItem, data: Dictionary).(_component) -> void:
+	set_title(data["name"] if data["title"] == "" else data["title"])
 	path = data["path"]
 	method_names = data["methods"]
-	_component.set_text(0, title)
 
 func add_method(tree: Tree, data: Dictionary) -> void:
 	var method = MethodTreeItem.new(tree.create_item(component), data["method"], path)
 	methods[method.path] = method
-	total += 1
-	component.set_text(0, "(%s/%s) %s" % [passed, total, title])
+	set_total(total + 1)
 	tree.scroll_to_item(method.component)
 
 func on_method_finished(data: Dictionary) -> void:
 	if data["success"]:
-		passed += 1
-	component.set_text(0, "(%s/%s) %s" % [passed, total, title])
+		set_passed(passed + 1)


### PR DESCRIPTION
I noticed that ```describe()``` works as intended if placed after the assertion. This is because in [ui/results/method.gd](https://github.com/AlexDarigan/WAT/blob/main/addons/WAT/ui/results/method.gd) line 26, the following code resets the title: ```component.set_text(0, "%s" % title)```. It's still a bug in my opinion since ```describe()``` should work regardless of execution order.

I've done a search and it doesn't seem that anything changes the title of the method after it is initialized. This means that line 26 is redundant and can be removed. To be sure, I checked the blame and it seems that this line was supposed to show the total number of assertions passed for that method in https://github.com/AlexDarigan/WAT/commit/06613e7035f946914e55269de8033df74c30b58a like so: ```component.set_text(0, "(%s/%s) %s" % [passed, total, title])```. However, it was set back to title in https://github.com/AlexDarigan/WAT/commit/35149606d564b280605b119cac79d9833e8d7f44 which should have been removed instead.

Because of this, it seems that there are plans to make this an option to be displayed in future. I can definitely see the need for number of assertions passed per test method. Therefore, instead of outright removing line 26, I refactored the code for the displaying of (total/passed) to make it more apparent, easier to maintain and extend, as well as fix #306.