### PR TITLE
Use signals for GUI debug to prevent endless yields caused by TestRunner crashes or debugger force stop

### DIFF
--- a/addons/WAT/network/test_server.gd
+++ b/addons/WAT/network/test_server.gd
@@ -1,36 +1,51 @@
 tool
 extends "res://addons/WAT/network/test_network.gd"
 
-enum STATE { SENDING, RECEIVING }
 signal network_peer_connected
 signal results_received
+
+enum STATE { SENDING, RECEIVING, DISCONNECTED }
+
 var _peer_id: int
+# Store incoming cases from client in case of abrupt termination.
+var caselist: Array = []
+var results_view: TabContainer
+var status: int = STATE.DISCONNECTED
 
 func _ready() -> void:
 	if not Engine.is_editor_hint():
 		return
 	custom_multiplayer.connect("network_peer_connected", self, "_on_network_peer_connected")
+	custom_multiplayer.connect("network_peer_disconnected", self, "_on_network_peer_disconnected")
 	if _error(_peer.create_server(PORT, MAXCLIENTS)) == OK:
 		custom_multiplayer.network_peer = _peer
 	
 func _on_network_peer_connected(id: int) -> void:
 	_peer_id = id
-	_peer.set_peer_timeout(id, 59000, 60000, 61000)
+	_peer.set_peer_timeout(id, 1000, 2000, 3000)
 	emit_signal("network_peer_connected")
-	
+
+func _on_network_peer_disconnected(_id: int) -> void:
+	if status == STATE.SENDING:
+		emit_signal("results_received", caselist)
+	caselist.clear()
+	status = STATE.DISCONNECTED
+
 func send_tests(testdir: Array, repeat: int, thread_count: int) -> void:
+	status = STATE.SENDING
 	rpc_id(_peer_id, "_on_tests_received_from_server", testdir, repeat, thread_count)
 
 master func _on_results_received_from_client(results: Array = []) -> void:
+	status = STATE.RECEIVING
 	emit_signal("results_received", results)
 	_peer.disconnect_peer(_peer_id, true)
-	
-var results_view: TabContainer
+
 master func _on_test_script_started(data: Dictionary) -> void:
 	results_view.on_test_script_started(data)
 	
 master func _on_test_script_finished(data: Dictionary) -> void:
 	results_view.on_test_script_finished(data)
+	caselist.append(data)
 
 master func _on_test_method_started(data: Dictionary) -> void:
 	results_view.on_test_method_started(data)


### PR DESCRIPTION
Fixes #316.

#### Changes
Whenever the test_client disconnects while running the tests, the test_server will now emit "results_received" but with whatever cases it currently has. This allows the GUI to always display the results eventually, without fail, and will not be stuck because it is done using signals. For debugger force stop (F8), the test_client doesn't actually disconnect from the test_server because it is terminated abruptly. So in this situation, it is the network peer timeout's job to disconnect the client. I changed the timeout from 61 seconds to 3 seconds.

#### Timeout Behavior
As described in [NetworkedMultiplayerENet](https://docs.godotengine.org/en/stable/classes/class_networkedmultiplayerenet.html#class-networkedmultiplayerenet-method-set-peer-timeout) docs, the timeout is determined as:

> a fixed timeout for which any packet must be acknowledged or the peer will be dropped.

Therefore, even if the peer is inactive for a long time, it will still be connected; it's only when it stops responding to polls that it will be kicked after 3 seconds. I tried writing a test script to yield for 10 seconds, performed the 10 second wait test by fd5ae8d9fd9d57b2006e142ec39fa95b8ba1325b, and it still did not end the test prematurely. Hence, I think changing the network peer timeout to 3 seconds is alright, at least for GUI debug's use case.