### PR TITLE
Improve test detection and include broken scripts in results

### DIFF
--- a/addons/WAT/filesystem/filesystem.gd
+++ b/addons/WAT/filesystem/filesystem.gd
@@ -89,6 +89,11 @@ func _get_test_script(p: String) -> TestScript:
 	if script:
 		var parse = script.reload(true)
 		if parse == OK and script.has_method("new"):
+			# TODO: Needs extra checking for invalid/uncompiled csharp scripts.
+			# Any errors about no method or new function new found exists here.
+			# has_method("new") returns true even for invalid csharp scripts,
+			# but when script.new() is called, it's says non-existent function.
+			# This is something that needs to be addressed at the engine level.
 			var test: Node = script.new()
 			if script.get("IS_WAT_TEST") or test.get("IS_WAT_TEST"):
 				test_script = TestScript.new(p, parse)

--- a/addons/WAT/filesystem/filesystem.gd
+++ b/addons/WAT/filesystem/filesystem.gd
@@ -16,12 +16,14 @@ var changed: bool = false setget _set_filesystem_changed
 var built: bool = false setget ,_get_filesystem_built # CSharpScript
 var build_function: FuncRef
 var index = {} # Path / Object
+var test_validator: Reference
 
 # Initialize/Save meta
 func _init(_build_function = null) -> void:
 	build_function = _build_function
 	tagged = TaggedTests.new(Settings)
 	failed = FailedTests.new()
+	test_validator = Validator.new()
 
 func _set_filesystem_changed(has_changed: bool) -> void:
 	changed = has_changed
@@ -84,7 +86,7 @@ func _get_root() -> TestDirectory:
 	return root
 		
 func _get_test_script(p: String) -> TestScript:
-	var test_validator = Validator.new(p, changed)
+	test_validator.load_path(p, changed)
 	var test_script: TestScript = null
 	if test_validator.is_valid_test():
 		test_script = TestScript.new(p, test_validator.get_load_error())

--- a/addons/WAT/filesystem/filesystem.gd
+++ b/addons/WAT/filesystem/filesystem.gd
@@ -84,7 +84,7 @@ func _get_root() -> TestDirectory:
 	return root
 		
 func _get_test_script(p: String) -> TestScript:
-	var test_validator = Validator.new(p)
+	var test_validator = Validator.new(p, changed)
 	var test_script: TestScript = null
 	if test_validator.is_valid_test():
 		test_script = TestScript.new(p, test_validator.get_load_error())

--- a/addons/WAT/filesystem/filesystem.gd
+++ b/addons/WAT/filesystem/filesystem.gd
@@ -89,11 +89,10 @@ func _get_test_script(p: String) -> TestScript:
 	var test_script: TestScript = TestScript.new()
 	test_script.parse = script.reload(true)
 	test_script.path = p
-	if test_script.parse == OK:
-		if script.get("IS_WAT_TEST"):
-			var test: Node = script.new()
+	if test_script.parse == OK and script.has_method("new"):
+		var test: Node = script.new()
+		if script.get("IS_WAT_TEST") or test.get("IS_WAT_TEST"):
 			test_script.names = test.get_test_methods()
-			test.free()
 			for m in test_script.names:
 				var test_method: TestMethod = TestMethod.new()
 				test_method.path = p
@@ -101,9 +100,10 @@ func _get_test_script(p: String) -> TestScript:
 				test_script.methods.append(test_method)
 				index[test_script.path+m] = test_method
 			if p.ends_with(".gd") or p.ends_with(".gdc"):
-				test_script.time = YieldCalculator.calculate_yield_time(load(p), test_script.names.size())
+				test_script.time = YieldCalculator.calculate_yield_time(script, test_script.names.size())
 		else:
 			test_script = null
+		test.free()
 	return test_script
 
 func clear() -> void:

--- a/addons/WAT/filesystem/filesystem.gd
+++ b/addons/WAT/filesystem/filesystem.gd
@@ -88,9 +88,12 @@ func _get_test_script(p: String) -> TestScript:
 	var test_script: TestScript = null
 	if test_validator.is_valid_test():
 		test_script = TestScript.new(p, test_validator.get_load_error())
-		var script_instance = test_validator.get_script_instance()
+		var script_instance = test_validator.script_instance
 		if script_instance:
 			test_script.names = script_instance.get_test_methods()
+			# Skip scripts with 0 defined test methods if validator allows.
+			if test_validator.skip_empty and test_script.names.empty():
+				return null
 			for m in test_script.names:
 				var test_method: TestMethod = TestMethod.new()
 				test_method.path = p
@@ -99,7 +102,7 @@ func _get_test_script(p: String) -> TestScript:
 				index[test_script.path+m] = test_method
 			if p.ends_with(".gd") or p.ends_with(".gdc"):
 				test_script.time = YieldCalculator.calculate_yield_time(
-						test_validator.get_script_resource(), test_script.names.size())
+						test_validator.script_resource, test_script.names.size())
 	return test_script
 
 func clear() -> void:

--- a/addons/WAT/filesystem/filesystem.gd
+++ b/addons/WAT/filesystem/filesystem.gd
@@ -18,7 +18,6 @@ var build_function: FuncRef
 var index = {} # Path / Object
 
 # Initialize/Save meta
-
 func _init(_build_function = null) -> void:
 	build_function = _build_function
 	tagged = TaggedTests.new(Settings)
@@ -30,7 +29,7 @@ func _set_filesystem_changed(has_changed: bool) -> void:
 		built = false
 
 func _get_filesystem_built() -> bool:
-	# If it is not Mono, automatically return true because it is irrelevant to GDScript.
+	# If not Mono, return true because it is irrelevant to GDScript.
 	return built or not Engine.is_editor_hint() or not ClassDB.class_exists("CSharpScript")
 
 func _recursive_update(testdir: TestDirectory) -> void:
@@ -74,7 +73,7 @@ func _recursive_update(testdir: TestDirectory) -> void:
 
 func update(testdir: TestDirectory = _get_root()) -> void:
 	_recursive_update(testdir)
-	# The changed attribute should be set to false after the update otherwise it is redundant.
+	# Set "changed" to false after the update, otherwise it is redundant.
 	changed = false
 		
 func _get_root() -> TestDirectory:
@@ -87,6 +86,7 @@ func _get_root() -> TestDirectory:
 func _get_test_script(p: String) -> TestScript:
 	var script = load(p)
 	if not script:
+		# If script is null, then it means it wasn't loaded, so exclude it.
 		return null
 	var test_script: TestScript = TestScript.new()
 	# reload() needed because load() still loads broken script, but the error..
@@ -108,10 +108,15 @@ func _get_test_script(p: String) -> TestScript:
 					test_script.time = YieldCalculator.calculate_yield_time(
 							script, test_script.names.size())
 			else:
+				# If the script has no load errors, yet it doesn't have the..
+				# ..IS_WAT_TEST attribute, then it should be excluded.
 				test_script = null
 			test.free()
 		else:
+			# The script has no load errors, yet it doesn't have the "new()"..
+			# ..method, so it is an invalid object that should be excluded.
 			test_script = null
+	# Loaded scripts with errors are still included.
 	return test_script
 
 func clear() -> void:

--- a/addons/WAT/filesystem/filesystem.gd
+++ b/addons/WAT/filesystem/filesystem.gd
@@ -87,13 +87,10 @@ func _get_test_script(p: String) -> TestScript:
 	var test_script: TestScript = null
 	var script = load(p)
 	if script:
-		var parse = script.reload(true)
-		if parse == OK and script.has_method("new"):
-			# TODO: Needs extra checking for invalid/uncompiled csharp scripts.
-			# Any errors about no method or new function new found exists here.
-			# has_method("new") returns true even for invalid csharp scripts,
-			# but when script.new() is called, it's says non-existent function.
-			# This is something that needs to be addressed at the engine level.
+		# Script resource with 0 methods signify parse error / uncompiled.
+		# Loaded scripts always have at least one method from its base class.
+		var parse = OK if not script.get_script_method_list().empty() else ERR_PARSE_ERROR
+		if parse == OK:
 			var test: Node = script.new()
 			if script.get("IS_WAT_TEST") or test.get("IS_WAT_TEST"):
 				test_script = TestScript.new(p, parse)

--- a/addons/WAT/filesystem/filesystem.gd
+++ b/addons/WAT/filesystem/filesystem.gd
@@ -86,6 +86,8 @@ func _get_root() -> TestDirectory:
 		
 func _get_test_script(p: String) -> TestScript:
 	var script = load(p)
+	if not script:
+		return null
 	var test_script: TestScript = TestScript.new()
 	test_script.parse = script.reload(true)
 	test_script.path = p

--- a/addons/WAT/filesystem/filesystem.gd
+++ b/addons/WAT/filesystem/filesystem.gd
@@ -89,23 +89,29 @@ func _get_test_script(p: String) -> TestScript:
 	if not script:
 		return null
 	var test_script: TestScript = TestScript.new()
+	# reload() needed because load() still loads broken script, but the error..
+	# .. is not in our control, so reload() will help us identify parse errors.
 	test_script.parse = script.reload(true)
 	test_script.path = p
-	if test_script.parse == OK and script.has_method("new"):
-		var test: Node = script.new()
-		if script.get("IS_WAT_TEST") or test.get("IS_WAT_TEST"):
-			test_script.names = test.get_test_methods()
-			for m in test_script.names:
-				var test_method: TestMethod = TestMethod.new()
-				test_method.path = p
-				test_method.name = m
-				test_script.methods.append(test_method)
-				index[test_script.path+m] = test_method
-			if p.ends_with(".gd") or p.ends_with(".gdc"):
-				test_script.time = YieldCalculator.calculate_yield_time(script, test_script.names.size())
+	if test_script.parse == OK:
+		if script.has_method("new"):
+			var test: Node = script.new()
+			if script.get("IS_WAT_TEST") or test.get("IS_WAT_TEST"):
+				test_script.names = test.get_test_methods()
+				for m in test_script.names:
+					var test_method: TestMethod = TestMethod.new()
+					test_method.path = p
+					test_method.name = m
+					test_script.methods.append(test_method)
+					index[test_script.path+m] = test_method
+				if p.ends_with(".gd") or p.ends_with(".gdc"):
+					test_script.time = YieldCalculator.calculate_yield_time(
+							script, test_script.names.size())
+			else:
+				test_script = null
+			test.free()
 		else:
 			test_script = null
-		test.free()
 	return test_script
 
 func clear() -> void:

--- a/addons/WAT/filesystem/method.gd
+++ b/addons/WAT/filesystem/method.gd
@@ -4,6 +4,10 @@ var path: String
 var dir: String setget ,_get_path
 var name: String setget ,_get_sanitized_name
 
+func _init(method_path: String = "", method_name: String = ""):
+	path = method_path
+	name = method_name
+
 # Method Name != test name
 func get_tests() -> Array:
 	return [{"dir": dir, "name": name, "path": self.path, "methods": [name], "time": 0.0}]

--- a/addons/WAT/filesystem/script.gd
+++ b/addons/WAT/filesystem/script.gd
@@ -6,6 +6,7 @@ var path: String setget ,_get_path
 var methods: Array # TestMethods
 var names: Array # MethodNames
 var time: float = 0.0 # YieldTime
+var parse: int # stores Error code (int)
 
 func _get_sanitized_name() -> String:
 	var n: String = path.substr(path.find_last("/") + 1)
@@ -19,4 +20,4 @@ func _get_path() -> String:
 	return path.replace("///", "//") # 
 
 func get_tests() -> Array:
-	return [{"dir": dir, "name": self.name, "path": self.path, "methods": names, "time": time}]
+	return [{"dir": dir, "name": self.name, "path": self.path, "methods": names, "time": time, "parse": parse}]

--- a/addons/WAT/filesystem/script.gd
+++ b/addons/WAT/filesystem/script.gd
@@ -6,7 +6,14 @@ var path: String setget ,_get_path
 var methods: Array # TestMethods
 var names: Array # MethodNames
 var time: float = 0.0 # YieldTime
-var parse: int # stores Error code (int)
+var parse: int # stores error code (int) of last load()
+
+# Constructor for script.gd reference.
+# script_path: Resource path of the script.
+# load_result: Error code when resource path is reloaded.
+func _init(script_path: String = "", load_result: int = OK):
+	path = script_path
+	parse = load_result
 
 func _get_sanitized_name() -> String:
 	var n: String = path.substr(path.find_last("/") + 1)

--- a/addons/WAT/filesystem/validator.gd
+++ b/addons/WAT/filesystem/validator.gd
@@ -47,10 +47,7 @@ func _is_valid_file() -> bool:
 			(ClassDB.class_exists("CSharpScript") and _is_valid_csharp())
 
 func is_valid_test() -> bool:
-	var resource = get_script_resource()
-	var instance = get_script_instance()
-	return resource and resource.get("IS_WAT_TEST") or \
-			instance and instance.get("IS_WAT_TEST") or \
+	return get_script_resource() and get_script_instance() or \
 			get_load_error() == ERR_PARSE_ERROR and _is_extending_wat_test()
 
 # Returns error code during resource load.
@@ -63,9 +60,11 @@ func get_load_error() -> int:
 				else ERR_PARSE_ERROR
 	return error
 
-func get_script_instance() -> Node:
+func get_script_instance():
 	# Create script_instance if no errors are found. Performed once and stored.
-	if not script_instance and get_load_error() == OK:
+	if not script_instance and get_load_error() == OK and \
+			(script_resource.get("IS_WAT_TEST") if not _is_valid_csharp() \
+			else _is_extending_wat_test()):
 		script_instance = script_resource.new()
 	return script_instance
 

--- a/addons/WAT/filesystem/validator.gd
+++ b/addons/WAT/filesystem/validator.gd
@@ -1,7 +1,8 @@
 extends Reference
-	
+
 static func is_valid_test(p: String) -> bool:
-	return _is_valid_gdscript(p) or _is_valid_compiled_gdscript(p) or _is_valid_csharp(p)
+	return _is_valid_gdscript(p) or _is_valid_compiled_gdscript(p) or \
+			(ClassDB.class_exists("CSharpScript") and _is_valid_csharp(p))
 			
 static func _is_valid_gdscript(p: String) -> bool:
 	return p.ends_with(".gd") and p != "res://addons/WAT/test/test.gd"

--- a/addons/WAT/filesystem/validator.gd
+++ b/addons/WAT/filesystem/validator.gd
@@ -12,12 +12,4 @@ static func _is_valid_compiled_gdscript(p: String) -> bool:
 static func _is_valid_csharp(p: String) -> bool:
 	# TODO: This requires extra checking for invalid or uncompiled csharp scripts
 	# Any errors about no method or new function new found exists here
-	if p.ends_with(".cs") and not "addons/WAT" in p and load(p).has_method("new"):
-		var test = load(p).new()
-		if test.get("IS_WAT_TEST"):
-			test.free()
-			return true
-		else:
-			test.free()
-			return false
-	return false
+	return p.ends_with(".cs") and not "addons/WAT" in p

--- a/addons/WAT/filesystem/validator.gd
+++ b/addons/WAT/filesystem/validator.gd
@@ -8,6 +8,8 @@ const REGEX_PATTERN = "(\\bextends\\s+WAT.Test\\b)" + \
 var path: String
 var script_resource: Script setget ,get_script_resource
 var script_instance: Node setget ,get_script_instance
+# If true, test scripts with 0 defined test methods should be skipped.
+var skip_empty: bool = true
 
 func _init(resource_path: String):
 	path = resource_path

--- a/addons/WAT/filesystem/validator.gd
+++ b/addons/WAT/filesystem/validator.gd
@@ -4,10 +4,10 @@ static func is_valid_test(p: String) -> bool:
 	return _is_valid_gdscript(p) or _is_valid_compiled_gdscript(p) or _is_valid_csharp(p)
 			
 static func _is_valid_gdscript(p: String) -> bool:
-	return p.ends_with(".gd") and p != "res://addons/WAT/test/test.gd" and load(p).get("IS_WAT_TEST")
+	return p.ends_with(".gd") and p != "res://addons/WAT/test/test.gd"
 	
 static func _is_valid_compiled_gdscript(p: String) -> bool:
-	return p.ends_with(".gdc") and p != "res://addons/WAT/test/test.gdc" and load(p).get("IS_WAT_TEST")
+	return p.ends_with(".gdc") and p != "res://addons/WAT/test/test.gdc"
 	
 static func _is_valid_csharp(p: String) -> bool:
 	# TODO: This requires extra checking for invalid or uncompiled csharp scripts

--- a/addons/WAT/filesystem/validator.gd
+++ b/addons/WAT/filesystem/validator.gd
@@ -1,14 +1,68 @@
 extends Reference
 
-static func is_valid_test(p: String) -> bool:
-	return _is_valid_gdscript(p) or _is_valid_compiled_gdscript(p) or \
-			(ClassDB.class_exists("CSharpScript") and _is_valid_csharp(p))
-			
-static func _is_valid_gdscript(p: String) -> bool:
-	return p.ends_with(".gd") and p != "res://addons/WAT/test/test.gd"
+# To search broken script source for WAT.Test usage.
+const REGEX_PATTERN = "(\\bextends\\s+WAT.Test\\b)" + \
+	"|(\\bextends\\b\\s+\\\"res:\\/\\/addons\\/WAT\\/test\\/test.gd\\\")" + \
+	"|(class\\s\\w[\\w<>]+\\s*:\\s*WAT.Test[\\s\\{])"
+
+var path: String
+var script_resource: Script setget ,get_script_resource
+var script_instance: Node setget ,get_script_instance
+
+func _init(resource_path: String):
+	path = resource_path
+	if _is_valid_file():
+		script_resource = ResourceLoader.load(path, "Script")
+
+# Frees the script_instance on destroy.
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_PREDELETE and is_instance_valid(script_instance):
+		script_instance.queue_free()
+
+# Checks if the Script's source has "extends WAT.Test"
+func _is_extending_wat_test() -> bool:
+	var result = null
+	if script_resource:
+		var regex = RegEx.new()
+		regex.compile(REGEX_PATTERN)
+		result = regex.search(script_resource.source_code)
+	return result != null
+
+func _is_valid_gdscript() -> bool:
+	return path.ends_with(".gd") and path != "res://addons/WAT/test/test.gd"
 	
-static func _is_valid_compiled_gdscript(p: String) -> bool:
-	return p.ends_with(".gdc") and p != "res://addons/WAT/test/test.gdc"
+func _is_valid_compiled_gdscript() -> bool:
+	return path.ends_with(".gdc") and path != "res://addons/WAT/test/test.gdc"
 	
-static func _is_valid_csharp(p: String) -> bool:
-	return p.ends_with(".cs") and not "addons/WAT" in p
+func _is_valid_csharp() -> bool:
+	return path.ends_with(".cs") and not "addons/WAT" in path
+
+func _is_valid_file() -> bool:
+	return _is_valid_gdscript() or _is_valid_compiled_gdscript() or \
+			(ClassDB.class_exists("CSharpScript") and _is_valid_csharp())
+
+func is_valid_test() -> bool:
+	var resource = get_script_resource()
+	var instance = get_script_instance()
+	return resource and resource.get("IS_WAT_TEST") or \
+			instance and instance.get("IS_WAT_TEST") or \
+			get_load_error() == ERR_PARSE_ERROR and _is_extending_wat_test()
+
+# Returns error code during resource load.
+func get_load_error() -> int:
+	var error = ERR_SKIP
+	if script_resource:
+		# Script resource with 0 methods signify parse error / uncompiled.
+		# Loaded scripts always have at least one method from its base class.
+		error = OK if not script_resource.get_script_method_list().empty() \
+				else ERR_PARSE_ERROR
+	return error
+
+func get_script_instance() -> Node:
+	# Create script_instance if no errors are found. Performed once and stored.
+	if not script_instance and get_load_error() == OK:
+		script_instance = script_resource.new()
+	return script_instance
+
+func get_script_resource() -> Script:
+	return script_resource

--- a/addons/WAT/filesystem/validator.gd
+++ b/addons/WAT/filesystem/validator.gd
@@ -7,19 +7,22 @@ const REGEX_PATTERN = "(\\bextends\\s+WAT.Test\\b)" + \
 
 var path: String
 var script_resource: Script setget ,get_script_resource
-var script_instance: Node setget ,get_script_instance
+var script_instance setget ,get_script_instance
 # If true, test scripts with 0 defined test methods should be skipped.
 var skip_empty: bool = true
 
-func _init(resource_path: String):
+func _init(resource_path: String, refresh: bool = true):
 	path = resource_path
 	if _is_valid_file():
-		script_resource = ResourceLoader.load(path, "Script")
+		# .cs scripts should load from cache due to how it is compiled.
+		# .gd scripts need to be reloaded on filesystem update.
+		script_resource = ResourceLoader.load(path, "Script",
+				refresh and not _is_valid_csharp())
 
 # Frees the script_instance on destroy.
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE and is_instance_valid(script_instance):
-		script_instance.queue_free()
+		script_instance.free()
 
 # Checks if the Script's source has "extends WAT.Test"
 func _is_extending_wat_test() -> bool:

--- a/addons/WAT/filesystem/validator.gd
+++ b/addons/WAT/filesystem/validator.gd
@@ -11,6 +11,4 @@ static func _is_valid_compiled_gdscript(p: String) -> bool:
 	return p.ends_with(".gdc") and p != "res://addons/WAT/test/test.gdc"
 	
 static func _is_valid_csharp(p: String) -> bool:
-	# TODO: This requires extra checking for invalid or uncompiled csharp scripts
-	# Any errors about no method or new function new found exists here
 	return p.ends_with(".cs") and not "addons/WAT" in p

--- a/addons/WAT/runner/test_controller.gd
+++ b/addons/WAT/runner/test_controller.gd
@@ -52,7 +52,7 @@ func run(metadata: Dictionary) -> void:
 	return test_results
 	
 func _on_test_script_started(data: Dictionary) -> void:
-	data["title"] = _test.title() if _test else data["name"]
+	data["title"] = _test.title() if is_instance_valid(_test) else data["name"]
 	if results != null:
 		results.on_test_script_started(data)
 

--- a/addons/WAT/runner/test_controller.gd
+++ b/addons/WAT/runner/test_controller.gd
@@ -12,27 +12,47 @@ signal results_received
 func run(metadata: Dictionary) -> void:
 	_dir = metadata["dir"]
 	_path = metadata["path"]
-	var methods = metadata["methods"]
-	_test = load(_path).new().setup(_dir, _path, methods)
+	var _methods = metadata["methods"]
 	
-	# Signals leak in C# so we're just using a direct connection and GetParent Calls
-	
-	_test.connect("test_method_started", self, "_on_test_method_started")
-	_test.connect("described", self, "_on_test_method_described")
-	_test.connect("asserted", self, "_on_asserted")
-	_test.connect("test_method_finished", self, "_on_test_method_finished")
-	_test.connect("test_script_finished", self, "_on_test_script_finished")
-	_on_test_script_started(metadata)
-	# We need to wait for the object itself to emit the signal (since we..
-	# ..cannot yield for C# so we defer the call to run so we have time to..
-	# ..to setup our yielding rather than deal with a race condition)
-	call_deferred("add_child", _test)
-	var results = yield(self, "results_received") # test_script_finished
-	_test.queue_free()
-	return results
+	# Default test results to -1 if there is a parse error, so the CLI or GUI will..
+	# ..know that an error had occurred.
+	var test_results = {
+		total = -1,
+		passed = -1,
+		context = metadata["name"],
+		methods = _methods,
+		success = false,
+		path = _path,
+		time_taken = metadata["time"],
+		dir = _dir
+	}
+
+	# If there was a parsing error, skip the test case.
+	if metadata.get("parse", OK) == OK:
+		# Signals leak in C# so we're just using a direct connection and GetParent Calls
+		_test = load(_path).new().setup(_dir, _path, _methods)
+		_test.connect("test_method_started", self, "_on_test_method_started")
+		_test.connect("described", self, "_on_test_method_described")
+		_test.connect("asserted", self, "_on_asserted")
+		_test.connect("test_method_finished", self, "_on_test_method_finished")
+		_test.connect("test_script_finished", self, "_on_test_script_finished")
+		_on_test_script_started(metadata) # Needs to be after _test is loaded.
+		
+		# We need to wait for the object itself to emit the signal (since we..
+		# ..cannot yield for C# so we defer the call to run so we have time to..
+		# ..to setup our yielding rather than deal with a race condition)
+		call_deferred("add_child", _test)
+		test_results = yield(self, "results_received") # test_script_finished
+		_test.queue_free()
+	else:
+		_on_test_script_started(metadata)
+		# Nothing to call_deferred here, so just yield for next idle_frame.
+		yield(get_tree(), "idle_frame")
+		_on_test_script_finished(test_results)
+	return test_results
 	
 func _on_test_script_started(data: Dictionary) -> void:
-	data["title"] = _test.title()
+	data["title"] = _test.title() if _test else data["name"]
 	if results != null:
 		results.on_test_script_started(data)
 

--- a/addons/WAT/runner/test_controller.gd
+++ b/addons/WAT/runner/test_controller.gd
@@ -44,6 +44,8 @@ func run(metadata: Dictionary) -> void:
 		call_deferred("add_child", _test)
 		test_results = yield(self, "results_received") # test_script_finished
 		_test.queue_free()
+		# Reset for the next case.
+		_test = null
 	else:
 		_on_test_script_started(metadata)
 		# Nothing to call_deferred here, so just yield for next idle_frame.

--- a/addons/WAT/ui/cli.gd
+++ b/addons/WAT/ui/cli.gd
@@ -110,7 +110,7 @@ func _threads() -> int:
 	
 
 func _display(cases: Dictionary) -> void:
-	cases.seconds = OS.get_ticks_msec() / 1000
+	cases.seconds = stepify(OS.get_ticks_msec() / 1000.0, 0.001)
 	_time_taken = cases.seconds
 	print("""
 	-------RESULTS-------

--- a/addons/WAT/ui/cli.gd
+++ b/addons/WAT/ui/cli.gd
@@ -123,14 +123,21 @@ func _display(cases: Dictionary) -> void:
 func _display_failures(case) -> void:
 	# We could create this somewhere else?
 	print("%s (%s)" % [case.context, case.path])
-	for method in case.methods:
-		if not method.success:
-			print("\n  %s" % method.context)
-			for assertion in method.assertions:
-				if not assertion.success:
-					print("\t%s" % assertion.context, "\n\t  (EXPECTED: %s) | (RESULTED: %s)" % [assertion.expected, assertion.actual])
+	match case.total:
+		-1:
+			print("\n  Parse Error (check syntax or broken dependencies)")
+		0:
+			print("\n  No Test Methods Defined")
+		_:
+			for method in case.methods:
+				if not method.success:
+					print("\n  %s" % method.context)
+					for assertion in method.assertions:
+						if not assertion.success:
+							print("\t%s" % assertion.context, 
+								"\n\t  (EXPECTED: %s) | (RESULTED: %s)" % \
+								[assertion.expected, assertion.actual])
 
 func _quit() -> void:
 	_filesystem.clear()
 	get_tree().quit()
-	

--- a/addons/WAT/ui/gui.gd
+++ b/addons/WAT/ui/gui.gd
@@ -74,11 +74,10 @@ func _on_run_pressed(data = _filesystem.root) -> void:
 		if not _filesystem.built:
 			current_build = false
 			_filesystem.built = yield(_filesystem.build_function.call_func(), "completed")
-			_filesystem.update()
 		if data == _filesystem.root:
 			_filesystem.update()
 			data = _filesystem.root # New Root
-		TestMenu.update_menus() # Also update the "Select Tests" dropdown
+			TestMenu.update_menus() # Also update the "Select Tests" dropdown
 	# Only run if the build is current and up to date.
 	if current_build:
 		var tests: Array = data.get_tests()
@@ -97,11 +96,10 @@ func _on_debug_pressed(data = _filesystem.root) -> void:
 		if not _filesystem.built:
 			current_build = false
 			_filesystem.built = yield(_filesystem.build_function.call_func(), "completed")
-			_filesystem.update()
 		if data == _filesystem.root:
 			_filesystem.update()
 			data = _filesystem.root # New Root
-		TestMenu.update_menus()
+			TestMenu.update_menus()
 
 	if current_build:
 		var tests: Array = data.get_tests()

--- a/addons/WAT/ui/gui.gd
+++ b/addons/WAT/ui/gui.gd
@@ -57,57 +57,65 @@ func setup_editor_context(plugin, build: FuncRef, goto_func: FuncRef, filesystem
 	_filesystem.update()
 	TestMenu.update_menus()
 	Server.results_view = Results
-	
+
+# Setup tests for display. Returns false if run should be terminated.
+func _setup_display(tests: Array) -> bool:
+	if tests.empty():
+		push_warning("WAT: No tests found. Terminating run")
+		return false
+	Summary.time()
+	Results.display(tests, Repeats.value)
+	return true
+
 func _on_run_pressed(data = _filesystem.root) -> void:
 	Results.clear()
-	
+	var current_build = true
 	if _filesystem.changed or not Settings.cache_tests():
 		if not _filesystem.built:
+			current_build = false
 			_filesystem.built = yield(_filesystem.build_function.call_func(), "completed")
-			return
+			_filesystem.update()
 		if data == _filesystem.root:
 			_filesystem.update()
 			data = _filesystem.root # New Root
-	
-	# Run
-	var tests: Array = data.get_tests()
-	if tests.empty():
-		push_warning("WAT: No tests found. Terminating run")
-		return
-	Summary.time()
-	Results.display(tests, Repeats.value)
-	var instance = preload("res://addons/WAT/runner/TestRunner.gd").new()
-	add_child(instance)
-	var results: Array = yield(instance.run(tests, Repeats.value, Threads.value, Results), "completed")
-	instance.queue_free()
-	_on_test_run_finished(results)
-	
+		TestMenu.update_menus() # Also update the "Select Tests" dropdown
+	# Only run if the build is current and up to date.
+	if current_build:
+		var tests: Array = data.get_tests()
+		if _setup_display(tests):
+			var instance = preload("res://addons/WAT/runner/TestRunner.gd").new()
+			add_child(instance)
+			var results: Array = yield(instance.run(tests, Repeats.value,
+					Threads.value, Results), "completed")
+			instance.queue_free()
+			_on_test_run_finished(results)
+
 func _on_debug_pressed(data = _filesystem.root) -> void:
 	Results.clear()
-	
+	var current_build = true
 	if _filesystem.changed or not Settings.cache_tests():
 		if not _filesystem.built:
+			current_build = false
 			_filesystem.built = yield(_filesystem.build_function.call_func(), "completed")
-			return
+			_filesystem.update()
 		if data == _filesystem.root:
 			_filesystem.update()
 			data = _filesystem.root # New Root
-			
-	var tests: Array = data.get_tests()
-	if tests.empty():
-		push_warning("WAT: No tests found. Terminating run")
-		return
-	Summary.time()
-	Results.display(tests, Repeats.value)
-	_plugin.get_editor_interface().play_custom_scene("res://addons/WAT/runner/TestRunner.tscn")
-	if Settings.is_bottom_panel():
-		_plugin.make_bottom_panel_item_visible(self)
-	yield(Server, "network_peer_connected")
-	Server.send_tests(tests, Repeats.value, Threads.value)
-	var results: Array = yield(Server, "results_received") #results_received
-	_plugin.get_editor_interface().stop_playing_scene() # Check if this works exported
-	_on_test_run_finished(results)
-	
+		TestMenu.update_menus()
+
+	if current_build:
+		var tests: Array = data.get_tests()
+		if _setup_display(tests):
+			_plugin.get_editor_interface().play_custom_scene(
+					"res://addons/WAT/runner/TestRunner.tscn")
+			if Settings.is_bottom_panel():
+				_plugin.make_bottom_panel_item_visible(self)
+			yield(Server, "network_peer_connected")
+			Server.send_tests(tests, Repeats.value, Threads.value)
+			var results: Array = yield(Server, "results_received")
+			_plugin.get_editor_interface().stop_playing_scene() # Check if this works exported
+			_on_test_run_finished(results)
+
 func _on_test_run_finished(results: Array) -> void:
 	Summary.summarize(results)
 	JUnitXML.write(results, Settings, Summary.time_taken)

--- a/addons/WAT/ui/results/tree.gd
+++ b/addons/WAT/ui/results/tree.gd
@@ -80,6 +80,13 @@ func on_test_script_finished(data: Dictionary) -> void:
 	_results.append(script.component)
 	if not success:
 		_failures.append(script.component)
+
+	if data["total"] < 0:
+		var message: TreeItem = create_item(script.component)
+		message.set_text(0, "Error parsing test script, check for syntax errors or broken dependencies")
+	elif data["total"] == 0:
+		var message: TreeItem = create_item(script.component)
+		message.set_text(0, "No test methods implemented")
 	
 func on_test_method_finished(data: Dictionary) -> void:
 	# On a finished method, change its color

--- a/addons/WAT/ui/test_menu.gd
+++ b/addons/WAT/ui/test_menu.gd
@@ -11,33 +11,29 @@ var filesystem
 var icons
 signal run_pressed
 signal debug_pressed
-signal built
 
 func _init() -> void:
 	_menu = PopupMenu.new()
 	add_child(_menu)
 
 func _pressed():
+	var current_build = true
 	if filesystem.changed:
 		if not filesystem.built:
-			build()
-			return
+			current_build = false
+			filesystem.built = yield(filesystem.build_function.call_func(), "completed")
 		filesystem.update()
 		update_menus()
-	var position: Vector2 = rect_global_position
-	position.y += rect_size.y
-	_menu.rect_global_position = position
-	_menu.rect_size = Vector2(rect_size.x, 0)
-	_menu.grab_focus()
-	_menu.popup()
+	if current_build:
+		var position: Vector2 = rect_global_position
+		position.y += rect_size.y
+		_menu.rect_global_position = position
+		_menu.rect_size = Vector2(rect_size.x, 0)
+		_menu.grab_focus()
+		_menu.popup()
 	
 func clear() -> void:
 	_menu.queue_free()
-	
-func build():
-	if not filesystem.built:
-		filesystem.built = yield(filesystem.build_function.call_func(), "completed")
-		return
 	
 func update_menus() -> void:
 	_menu.queue_free()

--- a/tests/bootstrap/mono/filesystem/FileSystemTest.cs
+++ b/tests/bootstrap/mono/filesystem/FileSystemTest.cs
@@ -5,7 +5,8 @@ using Godot;
 public class FileSystemTest : WAT.Test
 {
 	private string TemporaryPath = Godot.ProjectSettings
-		.GlobalizePath("res://") + "\\tests\\bootstrap\\filesystem\\temp\\";
+		.GlobalizePath("res://") + 
+		"\\tests\\bootstrap\\mono\\filesystem\\temp\\";
 	private GDScript FileSystem;
 
 

--- a/tests/bootstrap/mono/filesystem/FileSystemTest.cs
+++ b/tests/bootstrap/mono/filesystem/FileSystemTest.cs
@@ -1,0 +1,66 @@
+using Godot;
+
+[Start(nameof(Initialize))]
+[End(nameof(CleanUp))]
+public class FileSystemTest : WAT.Test
+{
+	private string TemporaryPath = Godot.ProjectSettings
+		.GlobalizePath("res://") + "\\tests\\bootstrap\\filesystem\\temp\\";
+	private GDScript FileSystem;
+
+
+	[Test("valid.test.gd", "extends WAT.Test\n\nfunc test_a():\n\tpass", 
+			true, "GDScript extending WAT.Test is valid test script")]
+	[Test("invalid.test.gd", "extends Node\n\nfunc test_b():\n\tpass",
+			false, "GDScript not extending WAT.Test is invalid")]
+	[Test("broken_ignore.test.gd", "nothingextends WAT.Test",
+			false, "GDScript with parse error is ignored")]
+	[Test("broken_accept.test.gd", "100 extends WAT.Test   : {abcd",
+			true, "GDScript error but extending WAT.Test is accepted")]
+	[Test("UncompiledWATTest.cs",
+			"using Godot;\nusing System;\n\npublic class " +
+			"UncompiledTest:WAT.Test{\n\t[Test]\n" +
+			"public void ATest(){Assert.Fail();}}",
+			true, "Uncompiled C# extending WAT.Test included")]
+	[Test("UncompiledIgnore.cs",
+			"using Godot;\nusing System;\n\npublic class " +
+			"UncompiledIgnore : SceneTree {\n\t[Test]\n" +
+			"public void ATest(){Assert.Fail();}}",
+			false, "Uncompiled C# not extending WAT.Test excluded")]
+	public void GetScript(string name, string content, 
+		bool expected, string context)
+	{
+		Describe(context);
+		// Generate test script file.
+		string path = TemporaryPath + name;
+		System.IO.File.WriteAllText(path, content);
+
+		// Perform test.
+		Object instance = (Godot.Object) FileSystem.New();
+		var result = instance.Call("_get_test_script", path);
+		if (expected)
+		{
+			Assert.IsNotNull(result);
+		}
+		else
+		{
+			Assert.IsNull(result);
+		}
+
+		// Cleanup generated test script file.
+		System.IO.File.Delete(path);
+	}
+
+	public void Initialize()
+	{
+		System.IO.Directory.CreateDirectory(TemporaryPath);
+		FileSystem = (GDScript) GD.Load(
+			"res://addons/WAT/filesystem/filesystem.gd");
+	}
+
+	public void CleanUp()
+	{
+		System.IO.Directory.Delete(TemporaryPath, true);
+	}
+
+}

--- a/tests/bootstrap/mono/filesystem/FileSystemTest.cs
+++ b/tests/bootstrap/mono/filesystem/FileSystemTest.cs
@@ -16,8 +16,10 @@ public class FileSystemTest : WAT.Test
 			true, "GDScript extending WAT.Test is valid test script")]
 	[Test("invalid.test.gd", "extends Node\n\nfunc test_b():\n\tpass",
 			false, "GDScript not extending WAT.Test is invalid")]
+	[Test("zero.test.gd", "extends WAT.Test", false,
+			"GDScript WAT.Test with 0 test methods are excluded by default")]
 	[Test("broken_ignore.test.gd", "nothingextends WAT.Test",
-			false, "GDScript with parse error is ignored")]
+			false, "Irrelevant GDScript with parse error is ignored")]
 	[Test("broken_accept.test.gd", "100 extends WAT.Test   : {abcd",
 			true, "GDScript error but extending WAT.Test is accepted")]
 	[Test("UncompiledWATTest.cs",

--- a/tests/bootstrap/mono/filesystem/FileSystemTest.cs
+++ b/tests/bootstrap/mono/filesystem/FileSystemTest.cs
@@ -1,12 +1,14 @@
 using Godot;
+using GDObject = Godot.Object;
+using System;
+using IO = System.IO;
 
 [Start(nameof(Initialize))]
 [End(nameof(CleanUp))]
 public class FileSystemTest : WAT.Test
 {
 	private string TemporaryPath = Godot.ProjectSettings
-		.GlobalizePath("res://") + 
-		"\\tests\\bootstrap\\mono\\filesystem\\temp\\";
+		.GlobalizePath("res://tests/bootstrap/mono/filesystem/temp/");
 	private GDScript FileSystem;
 
 
@@ -34,11 +36,12 @@ public class FileSystemTest : WAT.Test
 		Describe(context);
 		// Generate test script file.
 		string path = TemporaryPath + name;
-		System.IO.File.WriteAllText(path, content);
+		IO.File.WriteAllText(path, content);
 
 		// Perform test.
-		Object instance = (Godot.Object) FileSystem.New();
+		GDObject instance = (GDObject) FileSystem.New();
 		var result = instance.Call("_get_test_script", path);
+
 		if (expected)
 		{
 			Assert.IsNotNull(result);
@@ -49,19 +52,19 @@ public class FileSystemTest : WAT.Test
 		}
 
 		// Cleanup generated test script file.
-		System.IO.File.Delete(path);
+		IO.File.Delete(path);
 	}
 
 	public void Initialize()
 	{
-		System.IO.Directory.CreateDirectory(TemporaryPath);
+		IO.Directory.CreateDirectory(TemporaryPath);
 		FileSystem = (GDScript) GD.Load(
 			"res://addons/WAT/filesystem/filesystem.gd");
 	}
 
 	public void CleanUp()
 	{
-		System.IO.Directory.Delete(TemporaryPath, true);
+		IO.Directory.Delete(TemporaryPath, true);
 	}
 
 }


### PR DESCRIPTION
#### Description
This is an enhancement. Take your time in reviewing this change. More testing on edge cases may be needed to ensure it does not break other existing functionality before merging.

#### Before PR Behavior
Broken test scripts, uncompiled C# scripts, or those with no test methods are simply excluded from the test results altogether.


#### Problem
For GDScript especially, if a dependency is broken, simply running all tests will exclude the broken test and everything appears to be passing, but this can be detrimental if not caught by the user as mentioned in #314.


#### After PR Behavior
Using [```get_script_method_list()```](https://docs.godotengine.org/en/stable/classes/class_script.html#class-script-method-get-script-method-list), we can detect if a parse error has occurred or not, because a properly loaded script will always have at least one method from its base class (such as a constructor). A 0-method script resource is considered broken, and will be included in the test results as an automatic fail. In the testcase results data, I just set "total" and "passed" for broken cases to -1. An appropriate error message is shown. Any .cs or .gd script in the designated test folder will be picked up by validator.gd, and all checks to determine if a test is valid are properly contained in this class (functions no longer static).

.cs and .gd files in the test directory that will be read and included in the result:
- Any script extending WAT.Test but has test methods *(behaves normally)*
- Any script having parse errors (including uncompiled C# scripts) whose source code match a RegEx pattern (see fc98bf68709ff298d48d575a9b7b6ce1d4f42f12) suggesting that the class is extending WAT.Test *(will fail with "parse error")*

.cs and .gd files in the test directory that will not be included in the result:
- Any working script not extending WAT.Test
- Any working script extending WAT.Test but has 0 defined test methods *(this is the original behavior, but it can now be toggled using the skip_empty attribute in validator.gd; by default it is true, so it skips WAT.Test with 0 test methods, but if it is set to false, then it will be included in the result as an auto fail with "no test methods defined error")*
- Any broken script whose source code does not contain the extending WAT.Test RegEx pattern


#### Additional Information
- Uncompiled C# script resources are no longer instantiated, so the ```Invalid call. Nonexistent function `new` in base``` error is resolved
- Fixes Select Tests dropdown desync with C# scripts after building within the Godot engine
- CLI timer changed to 3 decimal places, consistent with GUI (see fdef9235de1701eb92f6d24d082fd58ba596dd21)
- Godot actually loads the script resource from cache, so changes to .gd files (interpreted as opposed to compiled) while the editor is running can actually cause a desync and the script retains its previously owned methods even after syntax is broken. I fixed this by setting a flag in ```ResourceLoader.load()``` to override this, but only for .gd scripts. This does not affect .cs scripts (see f2a703cdf634b65715cdfe56f3344d7d0f05a9cf)