### PR TITLE
Fix #333

### DIFF
--- a/addons/WAT/filesystem/script.gd
+++ b/addons/WAT/filesystem/script.gd
@@ -18,7 +18,7 @@ func _init(script_path: String = "", load_result: int = OK):
 func _get_sanitized_name() -> String:
 	var n: String = path.substr(path.find_last("/") + 1)
 	n = n.replace(".gd", "").replace(".gdc", "").replace(".cs", "")
-	n = n.replace(".test", "").replace("test", "").replace("_", " ")
+	n = n.replace(".test", "").replace("_", " ")
 	n[0] = n[0].to_upper()
 	return n
 	


### PR DESCRIPTION
Now it correctly finds the tests in a folder named tests or any folder name with the string 'test' in the path.
Not exactly sure why it was there, so maybe double checking would be in order