### PR TITLE
Fix #332 by having 10 minute timeout and kicking client on GUI debug

### DIFF
--- a/addons/WAT/network/test_server.gd
+++ b/addons/WAT/network/test_server.gd
@@ -22,7 +22,8 @@ func _ready() -> void:
 	
 func _on_network_peer_connected(id: int) -> void:
 	_peer_id = id
-	_peer.set_peer_timeout(id, 1000, 2000, 3000)
+	# Timeout is 10 minutes.
+	_peer.set_peer_timeout(id, 600000, 601000, 602000)
 	emit_signal("network_peer_connected")
 
 func _on_network_peer_disconnected(_id: int) -> void:
@@ -30,6 +31,13 @@ func _on_network_peer_disconnected(_id: int) -> void:
 		emit_signal("results_received", caselist)
 	caselist.clear()
 	status = STATE.DISCONNECTED
+
+func kick_current_peer():
+	var kicked = false
+	if _peer_id in custom_multiplayer.get_network_connected_peers():
+		_on_results_received_from_client([])
+		kicked = true
+	return kicked
 
 func send_tests(testdir: Array, repeat: int, thread_count: int) -> void:
 	status = STATE.SENDING

--- a/addons/WAT/ui/gui.gd
+++ b/addons/WAT/ui/gui.gd
@@ -58,7 +58,6 @@ func setup_editor_context(plugin, build: FuncRef, goto_func: FuncRef, filesystem
 	TestMenu.update_menus()
 	Server.results_view = Results
 
-
 # Setup tests for display. Returns false if run should be terminated.
 func _setup_display(tests: Array) -> bool:
 	if tests.empty():
@@ -67,7 +66,6 @@ func _setup_display(tests: Array) -> bool:
 	Summary.time()
 	Results.display(tests, Repeats.value)
 	return true
-
 
 func _on_run_pressed(data = _filesystem.root) -> void:
 	Results.clear()
@@ -104,6 +102,8 @@ func _on_debug_pressed(data = _filesystem.root) -> void:
 			TestMenu.update_menus()
 
 	if current_build:
+		if Server.kick_current_peer():
+				_plugin.get_editor_interface().stop_playing_scene()
 		var tests: Array = data.get_tests()
 		if _setup_display(tests):
 			_plugin.get_editor_interface().play_custom_scene(
@@ -113,12 +113,10 @@ func _on_debug_pressed(data = _filesystem.root) -> void:
 			yield(Server, "network_peer_connected")
 			Server.send_tests(tests, Repeats.value, Threads.value)
 			var results: Array = yield(Server, "results_received")
-			_plugin.get_editor_interface().stop_playing_scene() # Check if this works exported
+			_plugin.get_editor_interface().stop_playing_scene()
 			_on_test_run_finished(results)
 
-
 func _on_test_run_finished(results: Array) -> void:
-	_plugin.get_editor_interface().stop_playing_scene() # Check if this works exported
 	Summary.summarize(results)
 	JUnitXML.write(results, Settings, Summary.time_taken)
 	_filesystem.failed.update(results)


### PR DESCRIPTION
This fix does the following:
- Increase peer timeout to 10 minutes.
- On GUI debug start, if the peer is connected to the server, kick the peer and stop the yield.

This is to prevent debugger breakpoints for WAT Tests from timing out too early, and also to prevent a regression bug where if the debugger is force-stopped, it can never run again because it is still waiting for the peer to deliver the results.

With this fix, it enforces the fact that there can only be one test client connected at a time, which is the current behavior for GUI anyway, so this should be alright.

**Note that this fix affects GUI debug only.**