### PR TITLE
Add support for non-EventHandler based UntilEvent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@ data_*/
 
 # Rider
 .idea/
+
+# Visual Studio
+.vs/
+
+# Stub project
+bin/
+obj/

--- a/StubProj/StubProj.csproj
+++ b/StubProj/StubProj.csproj
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B27D149D-06FF-49F6-AF29-5802B9F4612C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>StubProj</RootNamespace>
+    <AssemblyName>StubProj</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+    <ProjectTypeGuids>{8F3E2DF0-C35C-4265-82FC-BEA011F4A7ED};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\*.csproj">
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/WAT5.sln
+++ b/WAT5.sln
@@ -1,12 +1,18 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WAT5", "WAT5.csproj", "{B55F6E5A-5EB7-49EC-AD95-87173756E436}"
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32630.194
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WAT5", "WAT5.csproj", "{B55F6E5A-5EB7-49EC-AD95-87173756E436}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StubProj", "StubProj\StubProj.csproj", "{B27D149D-06FF-49F6-AF29-5802B9F4612C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-	Debug|Any CPU = Debug|Any CPU
-	ExportDebug|Any CPU = ExportDebug|Any CPU
-	ExportRelease|Any CPU = ExportRelease|Any CPU
+		Debug|Any CPU = Debug|Any CPU
+		ExportDebug|Any CPU = ExportDebug|Any CPU
+		ExportRelease|Any CPU = ExportRelease|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B55F6E5A-5EB7-49EC-AD95-87173756E436}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -15,5 +21,21 @@ Global
 		{B55F6E5A-5EB7-49EC-AD95-87173756E436}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
 		{B55F6E5A-5EB7-49EC-AD95-87173756E436}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
 		{B55F6E5A-5EB7-49EC-AD95-87173756E436}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+		{B55F6E5A-5EB7-49EC-AD95-87173756E436}.Release|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{B55F6E5A-5EB7-49EC-AD95-87173756E436}.Release|Any CPU.Build.0 = ExportRelease|Any CPU
+		{B27D149D-06FF-49F6-AF29-5802B9F4612C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B27D149D-06FF-49F6-AF29-5802B9F4612C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B27D149D-06FF-49F6-AF29-5802B9F4612C}.ExportDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B27D149D-06FF-49F6-AF29-5802B9F4612C}.ExportDebug|Any CPU.Build.0 = Debug|Any CPU
+		{B27D149D-06FF-49F6-AF29-5802B9F4612C}.ExportRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{B27D149D-06FF-49F6-AF29-5802B9F4612C}.ExportRelease|Any CPU.Build.0 = Release|Any CPU
+		{B27D149D-06FF-49F6-AF29-5802B9F4612C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B27D149D-06FF-49F6-AF29-5802B9F4612C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {74D438C1-B368-4FC4-8414-6AD674386052}
 	EndGlobalSection
 EndGlobal

--- a/addons/WAT/double/script_director.gd
+++ b/addons/WAT/double/script_director.gd
@@ -59,7 +59,7 @@ func add_call(method: String, args: Array = []) -> void:
 	methods[method].add_call(args)
 	
 func set_methods() -> void:
-	var params: String = "abcdefghij"
+	var params: String = "abcdefghijklmnopqrstuvwxyz"
 	for m in method_list():
 		var arguments: String = ""
 		# m.args.size() causes crashes in release exports

--- a/addons/WAT/gui.tscn
+++ b/addons/WAT/gui.tscn
@@ -37,9 +37,6 @@ anchor_bottom = 1.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Core" type="VBoxContainer" parent="."]
 margin_left = 7.0
@@ -162,7 +159,7 @@ rect_min_size = Vector2( 160, 0 )
 size_flags_horizontal = 0
 size_flags_vertical = 0
 min_value = 1.0
-max_value = 7.0
+max_value = 15.0
 value = 1.0
 align = 1
 prefix = "Run on"

--- a/addons/WAT/mono/Test.cs
+++ b/addons/WAT/mono/Test.cs
@@ -6,206 +6,256 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Godot.Collections;
 using Object = Godot.Object;
+using Expression = System.Linq.Expressions.Expression;
 
-namespace WAT 
+namespace WAT
 {
-	[Start(nameof(Blank))]
-	[Pre(nameof(Blank))]
-	[Post(nameof(Blank))]
-	[End(nameof(Blank))]
-	public partial class Test : Node
-	{
-		[Signal] private delegate void EventRaised();
-		[Signal] public delegate void described();
-		private const int Recorder = 0; // Apparently we require the C# Version
-		private IEnumerable<Executable> _methods = null;
-		private Object _case = null;
-		private static GDScript TestCase { get; } = GD.Load<GDScript>("res://addons/WAT/test/case.gd");
-		private Reference _watcher { get; set; }
-		protected Timer Yielder { get; private set; }
-		protected Assertions Assert { get; private set; }
-		protected Type _type;
+    [Start(nameof(Blank))]
+    [Pre(nameof(Blank))]
+    [Post(nameof(Blank))]
+    [End(nameof(Blank))]
+    public partial class Test : Node
+    {
+        [Signal] private delegate void EventRaised();
+        [Signal] public delegate void described();
+        private const int Recorder = 0; // Apparently we require the C# Version
+        private IEnumerable<Executable> _methods = null;
+        private Object _case = null;
+        private static GDScript TestCase { get; } = GD.Load<GDScript>("res://addons/WAT/test/case.gd");
+        private Reference _watcher { get; set; }
+        protected Timer Yielder { get; private set; }
+        protected Assertions Assert { get; private set; }
+        protected Type _type;
 
-		protected Test() { _type = GetType(); }
-		public void Blank() { }
+        protected Test() { _type = GetType(); }
+        public void Blank() { }
 
-		public override void _Ready()
-		{
-		
-			_watcher = (Reference) GD.Load<GDScript>("res://addons/WAT/test/watcher.gd").New();
-			Yielder = (Timer) GD.Load<GDScript>("res://addons/WAT/test/yielder.gd").New();
-			Assert = new Assertions();
-			Assert.Connect(nameof(Assertions.asserted), _case, "_on_asserted");
-			Assert.Connect(nameof(Assertions.asserted), this, nameof(OnAssertion));
-			Connect(nameof(described), _case, "_on_test_method_described");
-			AddChild(Yielder);
-			CallDeferred(nameof(Run));
-		}
+        public override void _Ready()
+        {
 
-		private async void Run()
-		{
-			// Can we do this in _Ready
-			MethodInfo start = GetTestHook(typeof(StartAttribute));
-			MethodInfo pre = GetTestHook(typeof(PreAttribute));
-			MethodInfo post = GetTestHook(typeof(PostAttribute));
-			MethodInfo end = GetTestHook(typeof(EndAttribute));
-			await CallTestHook(start);
-			foreach (Executable test in _methods)
-			{
-				_case.Call("add_method", test.Method.Name);
-				EmitSignal(nameof(test_method_started), test.Method.Name);
-				await CallTestHook(pre);
-				await Execute(test);
-				EmitSignal(nameof(test_method_finished));
-				await CallTestHook(post);
-			}
+            _watcher = (Reference)GD.Load<GDScript>("res://addons/WAT/test/watcher.gd").New();
+            Yielder = (Timer)GD.Load<GDScript>("res://addons/WAT/test/yielder.gd").New();
+            Assert = new Assertions();
+            Assert.Connect(nameof(Assertions.asserted), _case, "_on_asserted");
+            Assert.Connect(nameof(Assertions.asserted), this, nameof(OnAssertion));
+            Connect(nameof(described), _case, "_on_test_method_described");
+            AddChild(Yielder);
+            CallDeferred(nameof(Run));
+        }
 
-			await CallTestHook(end);
-			EmitSignal(nameof(test_script_finished), GetResults());
-		}
-		
-		private string Title()
-		{
-			if (!Attribute.IsDefined(_type, typeof(TitleAttribute))) return _type.Name;
-			TitleAttribute title = (TitleAttribute) Attribute.GetCustomAttribute(_type, typeof(TitleAttribute));
-			return title.Title;
-		}
+        private async void Run()
+        {
+            // Can we do this in _Ready
+            MethodInfo start = GetTestHook(typeof(StartAttribute));
+            MethodInfo pre = GetTestHook(typeof(PreAttribute));
+            MethodInfo post = GetTestHook(typeof(PostAttribute));
+            MethodInfo end = GetTestHook(typeof(EndAttribute));
+            await CallTestHook(start);
+            foreach (Executable test in _methods)
+            {
+                _case.Call("add_method", test.Method.Name);
+                EmitSignal(nameof(test_method_started), test.Method.Name);
+                await CallTestHook(pre);
+                await Execute(test);
+                EmitSignal(nameof(test_method_finished));
+                await CallTestHook(post);
+            }
 
-		private MethodInfo GetTestHook(Type attributeType)
-		{
-			HookAttribute hook = (HookAttribute) Attribute.GetCustomAttribute(_type, attributeType);
-			return _type.GetMethod(hook.Method);
-		}
+            await CallTestHook(end);
+            EmitSignal(nameof(test_script_finished), GetResults());
+        }
 
-		private async Task CallTestHook(MethodInfo hook)
-		{
-			try {
-				if (hook.Invoke(this, null) is Task task) { await task; } else { await Task.Run((() => { })); }
-			} catch (Exception e) {
-				GD.PushError($"WAT: {e}");
-			}
-		}
+        private string Title()
+        {
+            if (!Attribute.IsDefined(_type, typeof(TitleAttribute))) return _type.Name;
+            TitleAttribute title = (TitleAttribute)Attribute.GetCustomAttribute(_type, typeof(TitleAttribute));
+            return title.Title;
+        }
 
-		private async Task Execute(Executable test)
-		{
-			try {
-				if (test.Method.Invoke(this, test.Arguments) is Task task) { await task; }
-				else { await Task.Run((() => { })); }
-			} catch (Exception e) {
-				GD.PushError($"WAT: {e}");
-			}
-		}
-		
-		protected void Describe(string description) 
-		{ 
-			EmitSignal(nameof(described), description);
-		}
+        private MethodInfo GetTestHook(Type attributeType)
+        {
+            HookAttribute hook = (HookAttribute)Attribute.GetCustomAttribute(_type, attributeType);
+            return _type.GetMethod(hook.Method);
+        }
 
-		protected SignalAwaiter UntilTimeout(double time) { return ToSignal((Timer) Yielder.Call("until_timeout", time), "finished"); }
+        private async Task CallTestHook(MethodInfo hook)
+        {
+            try
+            {
+                if (hook.Invoke(this, null) is Task task) { await task; } else { await Task.Run((() => { })); }
+            }
+            catch (Exception e)
+            {
+                GD.PushError($"WAT: {e}");
+            }
+        }
 
-		protected SignalAwaiter UntilSignal(Godot.Object emitter, string signal, double time)
-		{
-			_watcher.Call("watch", emitter, signal);
-			return ToSignal((Timer) Yielder.Call("until_signal", time, emitter, signal), "finished");
-		}
-		
-		protected async Task<TestEventData> UntilEvent(object sender, string handle, double time)
-		{
-			EventInfo eventInfo = sender.GetType().GetEvent(handle);
-			MethodInfo methodInfo = GetType().GetMethod("OnEventRaised");
-			Delegate handler = Delegate.CreateDelegate(eventInfo.EventHandlerType, this, methodInfo);
-			eventInfo.AddEventHandler(sender, handler);
-			object[] results = await UntilSignal(this, nameof(EventRaised), time);
-			eventInfo.RemoveEventHandler(sender, handler);
-			Godot.Collections.Array ourResults = (Godot.Collections.Array) results[0];
-			return (TestEventData) ourResults[0] ?? new TestEventData(null, null);
-		}
-		
-		public void OnEventRaised(object sender = null, EventArgs args = null)
-		{
-			EmitSignal(nameof(EventRaised), new TestEventData(sender, args));
-		}
+        private async Task Execute(Executable test)
+        {
+            try
+            {
+                if (test.Method.Invoke(this, test.Arguments) is Task task) { await task; }
+                else { await Task.Run((() => { })); }
+            }
+            catch (Exception e)
+            {
+                GD.PushError($"WAT: {e}");
+            }
+        }
 
-		protected async Task UntilEvent(object sender, string handle, double time, Delegate callback)
-		{
-			EventInfo eventInfo = sender.GetType().GetEvent(handle);
-			var parameters = eventInfo.EventHandlerType
-				.GetMethod("Invoke")
-				.GetParameters()
-				.Select(parameter => Expression.Parameter(parameter.ParameterType))
-				.ToArray();
+        protected void Describe(string description)
+        {
+            EmitSignal(nameof(described), description);
+        }
 
-			var handler = Expression.Lambda(
-					eventInfo.EventHandlerType,
-					Expression.Block(
-						Expression.Invoke(Expression.Constant(callback), parameters),
-						Expression.Call(Expression.Constant(this), GetType().GetMethod(nameof(OnEventWithCallbackRaised)))
-					),
-					parameters
-				)
-				.Compile();
-			eventInfo.AddEventHandler(sender, handler);
-			await UntilSignal(this, nameof(EventRaised), time);
-			eventInfo.RemoveEventHandler(sender, handler);
-		}
-		
-		public void OnEventWithCallbackRaised()
-		{
-			EmitSignal(nameof(EventRaised));
-		}
+        protected SignalAwaiter UntilTimeout(double time) { return ToSignal((Timer)Yielder.Call("until_timeout", time), "finished"); }
 
-		protected class TestEventData: Godot.Object
-		{
-			public object Sender { get; }
-			public EventArgs Arguments { get; }
+        protected SignalAwaiter UntilSignal(Godot.Object emitter, string signal, double time)
+        {
+            _watcher.Call("watch", emitter, signal);
+            return ToSignal((Timer)Yielder.Call("until_signal", time, emitter, signal), "finished");
+        }
 
-			public TestEventData(object sender, EventArgs arguments)
-			{
-				Sender = sender;
-				Arguments = arguments;
-			}
-		}
-		
-		protected void Watch(Godot.Object emitter, string signal) { _watcher.Call("watch", emitter, signal); }
-		protected void UnWatch(Godot.Object emitter, string signal) { _watcher.Call("unwatch", emitter, signal); }
-		
-		public void Simulate(Node obj, int times, float delta)
-		{
-			for (int i = 0; i < times; i++)
-			{
-				if (obj.HasMethod("_Process")) { obj._Process(delta); }
-				if (obj.HasMethod("_PhysicsProcess")) { obj._PhysicsProcess(delta); }
-				foreach (Node kid in obj.GetChildren()) { Simulate(kid, 1, delta); }
-			}
-		}
+        protected async Task<TestEventData> UntilEventHandlerEvent(object sender, string handle, double time)
+        {
+            EventInfo eventInfo = sender.GetType().GetEvent(handle);
+            MethodInfo methodInfo = GetType().GetMethod(nameof(OnEventHandlerEventRaised));
+            Delegate handler = Delegate.CreateDelegate(eventInfo.EventHandlerType, this, methodInfo);
+            eventInfo.AddEventHandler(sender, handler);
+            object[] results = await UntilSignal(this, nameof(EventRaised), time);
+            eventInfo.RemoveEventHandler(sender, handler);
+            Godot.Collections.Array ourResults = (Godot.Collections.Array)results[0];
+            return (TestEventData)ourResults[0] ?? new TestEventData(null, null);
+        }
 
-		private IEnumerable<Executable> GenerateTestMethods(IEnumerable<string> names)
-		{
-			return (from methodInfo in _type.GetMethods().Where(info => names.Contains(info.Name))
-				let tests = Attribute.GetCustomAttributes(methodInfo)
-					.OfType<TestAttribute>()
-				from attribute in tests
-				select new Executable(methodInfo, attribute.Arguments)).ToList();
-		}
-		
-		private Dictionary GetResults()
-		{
-			_case.Call("calculate"); // #")
-			Dictionary results = (Dictionary) _case.Call("to_dictionary");
-			_case.Free();
-			return results;
-		}
-		
-		private class Executable
-		{
-			public readonly MethodInfo Method;
-			public readonly object[] Arguments;
+        public void OnEventHandlerEventRaised(object sender = null, EventArgs args = null)
+        {
+            EmitSignal(nameof(EventRaised), new TestEventData(sender, args));
+        }
 
-			public Executable(MethodInfo method, object[] arguments)
-			{
-				Method = method;
-				Arguments = arguments;
-			}
-		}
-	}
+        #region UntilEvent<T>
+        protected Task<object[]> UntilEvent<T1>(object sender, string handle, double time, Action<T1> callback) => UntilEvent(sender, handle, time, (Delegate)callback);
+
+        protected Task<object[]> UntilEvent<T1, T2>(object sender, string handle, double time, Action<T1, T2> callback) => UntilEvent(sender, handle, time, (Delegate)callback);
+
+        protected Task<object[]> UntilEvent<T1, T2, T3>(object sender, string handle, double time, Action<T1, T2, T3> callback) => UntilEvent(sender, handle, time, (Delegate)callback);
+
+        protected Task<object[]> UntilEvent<T1, T2, T3, T4>(object sender, string handle, double time, Action<T1, T2, T3, T4> callback) => UntilEvent(sender, handle, time, (Delegate)callback);
+
+        protected Task<object[]> UntilEvent<T1, T2, T3, T4, T5>(object sender, string handle, double time, Action<T1, T2, T3, T4, T5> callback) => UntilEvent(sender, handle, time, (Delegate)callback);
+
+        protected Task<object[]> UntilEvent<T1, T2, T3, T4, T5, T6>(object sender, string handle, double time, Action<T1, T2, T3, T4, T5, T6> callback) => UntilEvent(sender, handle, time, (Delegate)callback);
+
+        protected Task<object[]> UntilEvent<T1, T2, T3, T4, T5, T6, T7>(object sender, string handle, double time, Action<T1, T2, T3, T4, T5, T6, T7> callback) => UntilEvent(sender, handle, time, (Delegate)callback);
+
+        protected Task<object[]> UntilEvent<T1, T2, T3, T4, T5, T6, T7, T8, T9>(object sender, string handle, double time, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> callback) => UntilEvent(sender, handle, time, (Delegate)callback);
+
+        protected Task<object[]> UntilEvent<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(object sender, string handle, double time, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> callback) => UntilEvent(sender, handle, time, (Delegate)callback);
+
+        protected Task<object[]> UntilEvent<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(object sender, string handle, double time, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> callback) => UntilEvent(sender, handle, time, (Delegate)callback);
+
+        protected Task<object[]> UntilEvent<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(object sender, string handle, double time, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> callback) => UntilEvent(sender, handle, time, (Delegate)callback);
+
+        protected Task<object[]> UntilEvent<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(object sender, string handle, double time, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> callback) => UntilEvent(sender, handle, time, (Delegate)callback);
+
+        protected Task<object[]> UntilEvent<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(object sender, string handle, double time, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> callback) => UntilEvent(sender, handle, time, (Delegate)callback);
+
+        protected Task<object[]> UntilEvent<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(object sender, string handle, double time, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> callback) => UntilEvent(sender, handle, time, (Delegate)callback);
+
+        protected Task<object[]> UntilEvent<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(object sender, string handle, double time, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> callback) => UntilEvent(sender, handle, time, (Delegate)callback);
+        #endregion
+
+        protected async Task<object[]> UntilEvent(object sender, string handle, double time, Delegate callback = null)
+        {
+            EventInfo eventInfo = sender.GetType().GetEvent(handle);
+            var parameters = eventInfo.EventHandlerType
+                .GetMethod("Invoke")
+                .GetParameters()
+                .Select(parameter => Expression.Parameter(parameter.ParameterType))
+                .ToArray();
+
+            Expression onEventRaisedInvoke = Expression.Call(Expression.Constant(this), GetType().GetMethod(nameof(OnEventRaised)), Expression.NewArrayInit(typeof(object), parameters.Select(x => Expression.Convert(x, typeof(object)))));
+            Expression body;
+            if (callback == null)
+                body = onEventRaisedInvoke;
+            else
+                body = Expression.Block(
+                    Expression.Invoke(Expression.Constant(callback), parameters),
+                    onEventRaisedInvoke
+                );
+
+            var handler = Expression.Lambda(
+                    eventInfo.EventHandlerType,
+                    body,
+                    parameters
+                )
+                .Compile();
+
+            eventInfo.AddEventHandler(sender, handler);
+            var results = await UntilSignal(this, nameof(EventRaised), time);
+            eventInfo.RemoveEventHandler(sender, handler);
+
+            var godotArray = (Godot.Collections.Array)results.First();
+            return godotArray.Cast<object>().Take(parameters.Length).ToArray();
+        }
+
+        public void OnEventRaised(params object[] parameters)
+        {
+            EmitSignal(nameof(EventRaised), parameters);
+        }
+
+        protected class TestEventData : Godot.Object
+        {
+            public object Sender { get; }
+            public EventArgs Arguments { get; }
+
+            public TestEventData(object sender, EventArgs arguments)
+            {
+                Sender = sender;
+                Arguments = arguments;
+            }
+        }
+
+        protected void Watch(Godot.Object emitter, string signal) { _watcher.Call("watch", emitter, signal); }
+        protected void UnWatch(Godot.Object emitter, string signal) { _watcher.Call("unwatch", emitter, signal); }
+
+        public void Simulate(Node obj, int times, float delta)
+        {
+            for (int i = 0; i < times; i++)
+            {
+                if (obj.HasMethod("_Process")) { obj._Process(delta); }
+                if (obj.HasMethod("_PhysicsProcess")) { obj._PhysicsProcess(delta); }
+                foreach (Node kid in obj.GetChildren()) { Simulate(kid, 1, delta); }
+            }
+        }
+
+        private IEnumerable<Executable> GenerateTestMethods(IEnumerable<string> names)
+        {
+            return (from methodInfo in _type.GetMethods().Where(info => names.Contains(info.Name))
+                    let tests = Attribute.GetCustomAttributes(methodInfo)
+                        .OfType<TestAttribute>()
+                    from attribute in tests
+                    select new Executable(methodInfo, attribute.Arguments)).ToList();
+        }
+
+        private Dictionary GetResults()
+        {
+            _case.Call("calculate"); // #")
+            Dictionary results = (Dictionary)_case.Call("to_dictionary");
+            _case.Free();
+            return results;
+        }
+
+        private class Executable
+        {
+            public readonly MethodInfo Method;
+            public readonly object[] Arguments;
+
+            public Executable(MethodInfo method, object[] arguments)
+            {
+                Method = method;
+                Arguments = arguments;
+            }
+        }
+    }
 }

--- a/addons/WAT/test/watcher.gd
+++ b/addons/WAT/test/watcher.gd
@@ -12,8 +12,8 @@ func watch(emitter, event: String) -> void:
 	watching[event] = {emit_count = 0, calls = []}
 
 
-func _add_emit(a = null, b = null, c = null, d = null, e = null, f = null, g = null, h = null, i = null, j = null, k = null):
-	var arguments: Array = [a, b, c, d, e, f, g, h, i, j, k]
+func _add_emit(a = null, b = null, c = null, d = null, e = null, f = null, g = null, h = null, i = null, j = null, k = null, l = null, m = null, n = null, o = null, p = null, q = null, r = null, s = null, t = null, u = null, v = null, w = null, x = null, y = null, z = null):
+	var arguments: Array = [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
 	var event
 	while not event:
 		event = arguments.pop_back()

--- a/project.godot
+++ b/project.godot
@@ -87,7 +87,7 @@ Cache_Tests=true
 [application]
 
 config/name="WAT5"
-run/main_scene="res://OldExamples/Node.tscn"
+run/main_scene="res://addons/WAT/gui.tscn"
 config/icon="res://icon.svg"
 
 [editor_plugins]

--- a/tests/bootstrap/mono/UntilEvent.cs
+++ b/tests/bootstrap/mono/UntilEvent.cs
@@ -3,93 +3,116 @@ using System.Threading.Tasks;
 
 namespace WAT
 {
-	public class UntilEvent: WAT.Test
-	{
-		// This should really work with any delegate that matches method(sender), method(sender, args) or method(sender, customargs)
-		public event EventHandler Event;
-		public event EventHandler<EventArgs> EventWithArguments;
-		public event EventHandler<CustomEventArgs> EventWithCustomArguments;
-		
-		[Test()]
-		public async Task EventReached()
-		{
-			Watch(this, "EventRaised");
-			CallDeferred("InvokeEvent");
-			TestEventData eventData = await UntilEvent(this, nameof(Event), 10.0);
-			Assert.IsEqual(eventData.Sender, this, "This test invoked Event");
-			Assert.SignalWasEmitted(this, "EventRaised", "EventRaised Emitted");
-			UnWatch(this, "EventRaised");
-		}
-		
-		[Test()]
-		public async Task EventTimedOut()
-		{
-			Watch(this, "EventRaised");
-			TestEventData eventData = await UntilEvent(this, nameof(Event), 0.5);
-			Assert.IsTrue(eventData.Sender is null, "Event data has no sender (because it was never invoked)");
-			Assert.SignalWasNotEmitted(this, "EventRaised", "EventRaised was not Emitted");
-			UnWatch(this, "EventRaised");
-		}
-		
-		[Test()]
-		public async Task EventWithArgsReached()
-		{
-			Watch(this, "EventRaised");
-			CallDeferred("InvokeEventWithEventArgs");
-			TestEventData eventData  = await UntilEvent(this, nameof(EventWithArguments), 10.0);
-			Assert.IsEqual(eventData.Sender, this, "This test invoked EventWithEventArgs");
-			Assert.SignalWasEmitted(this, "EventRaised", "EventRaised Emitted");
-			UnWatch(this, "EventRaised");
-		}
-		
-		[Test()]
-		public async Task EventWithArgsTimedOut()
-		{
-			Watch(this, "EventRaised");
-			TestEventData eventData = await UntilEvent(this, nameof(EventWithArguments), 0.5);
-			Assert.IsTrue(eventData.Sender is null, "Event data has no sender (because it was never invoked)");
-			Assert.SignalWasNotEmitted(this, "EventRaised", "EventRaised was not Emitted");
-			UnWatch(this, "EventRaised");
-		}
-		
-		[Test()]
-		public async Task EventWithCustomArgsReached()
-		{
-			Watch(this, "EventRaised");
-			CallDeferred("InvokeEventWithCustomArgs", 10, "hello", true);
-			TestEventData eventData = await UntilEvent(this, nameof(EventWithCustomArguments), 10.0);
-			Assert.IsEqual(eventData.Sender, this, "This test invoked EventWithEventArgs");
-			Assert.SignalWasEmitted(this, "EventRaised", "EventRaised Emitted");
-			Assert.IsType<CustomEventArgs>(eventData.Arguments, "Args are Custom Event Args");
-			UnWatch(this, "EventRaised");
-		}
-		
-		[Test()]
-		public async Task EventWithCustomArgsTimedOut()
-		{
-			Watch(this, "EventRaised");
-			TestEventData eventData = await UntilEvent(this, nameof(EventWithCustomArguments), 0.5);
-			Assert.IsTrue(eventData.Sender is null, "Event data has no sender (because it was never invoked)");
-			Assert.SignalWasNotEmitted(this, "EventRaised", "EventRaised Was Not Emitted");
-			UnWatch(this, "EventRaised");
-		}
-		
-		private void InvokeEvent() { Event?.Invoke(this, null); }
-		private void InvokeEventWithEventArgs() { EventWithArguments?.Invoke(this, new EventArgs()); }
-		private void InvokeEventWithCustomArgs(int a, string b, bool c) { EventWithCustomArguments?.Invoke(this, new CustomEventArgs(a, b, c)); }
-	}
+    public class UntilEvent : WAT.Test
+    {
+        // This should really work with any delegate that matches method(sender), method(sender, args) or method(sender, customargs)
+        public event Action Event;
+        public event Action<string> EventWithArgument;
+        public event Action<int, string, bool> EventWithThreeArguments;
 
-	public class CustomEventArgs: EventArgs
-	{
-		public int A { get; }
-		public string B { get; }
-		public bool C { get; }
-			
-		public CustomEventArgs(int a, string b, bool c)
-		{
-			A = a;
-			B = b;
-			C = c;
-		}
-	}
+        [Test()]
+        public async Task EventReached()
+        {
+            Watch(this, "EventRaised");
+            CallDeferred(nameof(InvokeEvent));
+            await UntilEvent(this, nameof(Event), 10.0);
+            Assert.SignalWasEmitted(this, "EventRaised", "EventRaised Emitted");
+            UnWatch(this, "EventRaised");
+        }
+
+        [Test()]
+        public async Task EventTimedOut()
+        {
+            Watch(this, "EventRaised");
+            await UntilEvent(this, nameof(Event), 0.5);
+            Assert.SignalWasNotEmitted(this, "EventRaised", "EventRaised was not Emitted");
+            UnWatch(this, "EventRaised");
+        }
+
+        [Test()]
+        public async Task EventWithArgsReached()
+        {
+            Watch(this, "EventRaised");
+            CallDeferred(nameof(InvokeEventWithArg), "hello");
+            var isCalled = new Ref<bool>();
+            var args = await UntilEvent(this, nameof(EventWithArgument), 10.0, (string a) =>
+            {
+                isCalled.value = true;
+                Assert.IsEqual(a, "hello", "Callback a = 'hello'");
+            });
+            Assert.SignalWasEmitted(this, "EventRaised", "EventRaised Emitted");
+            Assert.IsTrue(isCalled.value, "Callback Called");
+            Assert.IsEqual(args.Length, 1, "Expected 1 Argument");
+            Assert.IsEqual(args[0], "hello", "Return a = 'hello'");
+            UnWatch(this, "EventRaised");
+        }
+
+        protected class Ref<T>
+        {
+            public T value;
+
+            public Ref(T value = default(T))
+            {
+                this.value = value;
+            }
+        }
+
+        [Test()]
+        public async Task EventWithArgsTimedOut()
+        {
+            Watch(this, "EventRaised");
+            var isCalled = new Ref<bool>();
+            var args = await UntilEvent(this, nameof(EventWithArgument), 0.5, (string text) =>
+            {
+                isCalled.value = true;
+            });
+            Assert.SignalWasNotEmitted(this, "EventRaised", "EventRaised was not Emitted");
+            Assert.IsEqual(args.Length, 1, "Expected 1 Argument");
+            Assert.IsNull(args[0], "Expected Argument[0] == Null");
+            Assert.IsFalse(isCalled.value, "Callback Should Not Be Called");
+            UnWatch(this, "EventRaised");
+        }
+
+        [Test()]
+        public async Task EventWithCustomArgsReached()
+        {
+            Watch(this, "EventRaised");
+            CallDeferred(nameof(InvokeEventWithThreeArgs), 10, "hello", true);
+            var isCalled = new Ref<bool>();
+            var args = await UntilEvent(this, nameof(EventWithThreeArguments), 10.0, (int a, string b, bool c) =>
+            {
+                isCalled.value = true;
+                Assert.IsEqual(a, 10, "Callback a = 10");
+                Assert.IsEqual(b, "hello", "Callback b = 'hello'");
+                Assert.IsEqual(c, true, "Callback c = true");
+            });
+            Assert.SignalWasEmitted(this, "EventRaised", "EventRaised Emitted");
+            Assert.IsTrue(isCalled.value, "Callback Called");
+            Assert.IsEqual(args.Length, 3, "Expected 3 Arguments");
+            Assert.IsEqual(args[0], 10, "Return a = 10");
+            Assert.IsEqual(args[1], "hello", "Return b = 'hello'");
+            Assert.IsEqual(args[2], true, "Return c = true");
+
+            UnWatch(this, "EventRaised");
+        }
+
+        [Test()]
+        public async Task EventWithCustomArgsTimedOut()
+        {
+            Watch(this, "EventRaised");
+            var isCalled = new Ref<bool>();
+            var args = await UntilEvent(this, nameof(EventWithThreeArguments), 0.5);
+            Assert.SignalWasNotEmitted(this, "EventRaised", "EventRaised Was Not Emitted");
+            Assert.IsEqual(args.Length, 3, "Expected 3 Arguments");
+            Assert.IsNull(args[0], "Expected Argument[0] == Null");
+            Assert.IsNull(args[1], "Expected Argument[1] == Null");
+            Assert.IsNull(args[2], "Expected Argument[2] == Null");
+            Assert.IsFalse(isCalled.value, "Callback Not Called");
+            UnWatch(this, "EventRaised");
+        }
+
+        private void InvokeEvent() { Event?.Invoke(); }
+        private void InvokeEventWithArg(string a) { EventWithArgument?.Invoke(a); }
+        private void InvokeEventWithThreeArgs(int a, string b, bool c) { EventWithThreeArguments?.Invoke(a, b, c); }
+    }
 }

--- a/tests/bootstrap/mono/UntilEventHandlerEvent.cs
+++ b/tests/bootstrap/mono/UntilEventHandlerEvent.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Threading.Tasks;
+
+namespace WAT
+{
+    public class UntilEventHandlerEvent : WAT.Test
+    {
+        // This should really work with any delegate that matches method(sender), method(sender, args) or method(sender, customargs)
+        public event EventHandler Event;
+        public event EventHandler<EventArgs> EventWithArguments;
+        public event EventHandler<CustomEventArgs> EventWithCustomArguments;
+
+        [Test()]
+        public async Task EventReached()
+        {
+            Watch(this, "EventRaised");
+            CallDeferred(nameof(InvokeEvent));
+            TestEventData eventData = await UntilEventHandlerEvent(this, nameof(Event), 10.0);
+            Assert.IsEqual(eventData.Sender, this, "This test invoked Event");
+            Assert.SignalWasEmitted(this, "EventRaised", "EventRaised Emitted");
+            UnWatch(this, "EventRaised");
+        }
+
+        [Test()]
+        public async Task EventTimedOut()
+        {
+            Watch(this, "EventRaised");
+            TestEventData eventData = await UntilEventHandlerEvent(this, nameof(Event), 0.5);
+            Assert.IsTrue(eventData.Sender is null, "Event data has no sender (because it was never invoked)");
+            Assert.SignalWasNotEmitted(this, "EventRaised", "EventRaised was not Emitted");
+            UnWatch(this, "EventRaised");
+        }
+
+        [Test()]
+        public async Task EventWithArgsReached()
+        {
+            Watch(this, "EventRaised");
+            CallDeferred(nameof(InvokeEventWithEventArgs));
+            TestEventData eventData = await UntilEventHandlerEvent(this, nameof(EventWithArguments), 10.0);
+            Assert.IsEqual(eventData.Sender, this, "This test invoked EventWithEventArgs");
+            Assert.SignalWasEmitted(this, "EventRaised", "EventRaised Emitted");
+            UnWatch(this, "EventRaised");
+        }
+
+        [Test()]
+        public async Task EventWithArgsTimedOut()
+        {
+            Watch(this, "EventRaised");
+            TestEventData eventData = await UntilEventHandlerEvent(this, nameof(EventWithArguments), 0.5);
+            Assert.IsTrue(eventData.Sender is null, "Event data has no sender (because it was never invoked)");
+            Assert.SignalWasNotEmitted(this, "EventRaised", "EventRaised was not Emitted");
+            UnWatch(this, "EventRaised");
+        }
+
+        [Test()]
+        public async Task EventWithCustomArgsReached()
+        {
+            Watch(this, "EventRaised");
+            CallDeferred(nameof(InvokeEventWithCustomArgs), 10, "hello", true);
+            TestEventData eventData = await UntilEventHandlerEvent(this, nameof(EventWithCustomArguments), 10.0);
+            Assert.IsEqual(eventData.Sender, this, "This test invoked EventWithEventArgs");
+            Assert.SignalWasEmitted(this, "EventRaised", "EventRaised Emitted");
+            Assert.IsType<CustomEventArgs>(eventData.Arguments, "Args are Custom Event Args");
+            UnWatch(this, "EventRaised");
+        }
+
+        [Test()]
+        public async Task EventWithCustomArgsTimedOut()
+        {
+            Watch(this, "EventRaised");
+            TestEventData eventData = await UntilEventHandlerEvent(this, nameof(EventWithCustomArguments), 0.5);
+            Assert.IsTrue(eventData.Sender is null, "Event data has no sender (because it was never invoked)");
+            Assert.SignalWasNotEmitted(this, "EventRaised", "EventRaised Was Not Emitted");
+            UnWatch(this, "EventRaised");
+        }
+
+        private void InvokeEvent() { Event?.Invoke(this, null); }
+        private void InvokeEventWithEventArgs() { EventWithArguments?.Invoke(this, new EventArgs()); }
+        private void InvokeEventWithCustomArgs(int a, string b, bool c) { EventWithCustomArguments?.Invoke(this, new CustomEventArgs(a, b, c)); }
+    }
+
+    public class CustomEventArgs : EventArgs
+    {
+        public int A { get; }
+        public string B { get; }
+        public bool C { get; }
+
+        public CustomEventArgs(int a, string b, bool c)
+        {
+            A = a;
+            B = b;
+            C = c;
+        }
+    }
+}

--- a/tests/examples/csharp/AwaitTest.cs
+++ b/tests/examples/csharp/AwaitTest.cs
@@ -4,93 +4,126 @@ using System.Threading.Tasks;
 
 public class AwaitTest : WAT.Test
 {
-	[Signal] public delegate void MySignal();
+    [Signal] public delegate void MySignal();
 
-	public event EventHandler MyEvent;
-	public event EventHandler MyEventWithArgs;
-	
-	// In Addition to the Tests below, Developers may also await..
-	// ..any method that is targeted by the the [Start], [Pre]..
-	// ..[Post], [End] attributes provided they change the..
-	// ..targeted method's signature to async task.
+    public event EventHandler MyEventHandlerEvent;
+    public event EventHandler MyEventHandlerEventWithArgs;
 
-	[Test]
-	public async Task AwaitUntilTimeout()
-	{
-		// Developers may await in tests for a set of amount of..
-		// ..time by changing the Test Method signature to..
-		// ..async Task while calling await UntilTimeout.
-		await UntilTimeout(0.2f);
-		Assert.AutoPass("Await Until Timeout");
-	}
+    public event Action MyActionEvent;
+    public event Action<string, int> MyActionEventWithArgs;
 
-	[Test]
-	public async Task AwaitUntilSignal()
-	{
-		// Developers may await in tests for a signal by..
-		// ..changing the Test Method signature to async task..
-		// ..and awaiting UntilSignal passing in the emitter..
-		// ..object, the string signal and the time limit.
-		CallDeferred("emit_signal", nameof(MySignal));
-		await UntilSignal(this, nameof(MySignal), 0.2f);
-		Assert.AutoPass("Await Until Signal");
-	}
+    // In Addition to the Tests below, Developers may also await..
+    // ..any method that is targeted by the the [Start], [Pre]..
+    // ..[Post], [End] attributes provided they change the..
+    // ..targeted method's signature to async task.
 
-	[Test]
-	public async Task AwaitUntilEvent()
-	{
-		// Developers may await in tests for an Event with no EventArgs..
-		// ..by changing the Test Method signature to async task and..
-		// ..awaiting UntilEvent passing in the Event sender, the event..
-		// ..handle and a time limit.
-		// Note: Currently WAT only handles Event handles that take the..
-		// ..the sender and an optional EventArg object.
-		CallDeferred(nameof(InvokeEventWithNoArgs));
-		await UntilEvent(this, nameof(MyEvent), 0.2f);
-		Assert.AutoPass("Await Until Event");
-	}
+    [Test]
+    public async Task AwaitUntilTimeout()
+    {
+        // Developers may await in tests for a set of amount of..
+        // ..time by changing the Test Method signature to..
+        // ..async Task while calling await UntilTimeout.
+        await UntilTimeout(0.2f);
+        Assert.AutoPass("Await Until Timeout");
+    }
 
-	[Test]
-	public async Task AwaitUntilEventWithArgs()
-	{
-		// Developers may await in tests for an Event with EventArgs..
-		// ..by changing the Test Method signature to async task and..
-		// ..awaiting UntilEvent passing in the Event sender, the event..
-		// ..handle and a time limit.
-		// Note: Currently WAT only handles Event handles that take the..
-		// ..the sender and an optional EventArg Object.
-		CallDeferred(nameof(InvokeEventWithEventArgs), "Hello", "Alex");
-		
-		// Developers may investigate TestEventData object returned by UntilEvent..
-		// ..which containers the property Sender and the property Arguments which..
-		// ..stores the EventArg object that may have been sent.
-		TestEventData data = 
-			await UntilEvent(this, nameof(MyEventWithArgs), 0.2f);
-		GreetingArgs args = (GreetingArgs) data.Arguments;
-		Assert.IsEqual(args.Greeting, "Hello");
-		Assert.IsEqual(args.Name, "Alex");
-	}
+    [Test]
+    public async Task AwaitUntilSignal()
+    {
+        // Developers may await in tests for a signal by..
+        // ..changing the Test Method signature to async task..
+        // ..and awaiting UntilSignal passing in the emitter..
+        // ..object, the string signal and the time limit.
+        CallDeferred("emit_signal", nameof(MySignal));
+        await UntilSignal(this, nameof(MySignal), 0.2f);
+        Assert.AutoPass("Await Until Signal");
+    }
 
-	private void InvokeEventWithNoArgs()
-	{
-		MyEvent?.Invoke(this, null);
-	}
+    [Test]
+    public async Task AwaitUntilEvent()
+    {
+        // Developers may await in tests for an Event with no EventArgs..
+        // ..by changing the Test Method signature to async task and..
+        // ..awaiting UntilEvent passing in the Event sender, the event..
+        // ..handle and a time limit.
+        // Note: Currently WAT only handles Event handles that take the..
+        // ..the sender and an optional EventArg object.
+        CallDeferred(nameof(InvokeEventHandlerEventWithNoArgs));
+        await UntilEvent(this, nameof(MyEventHandlerEvent), 0.2f);
+        Assert.AutoPass("Await Until Event");
+    }
 
-	private void InvokeEventWithEventArgs(string greeting, string name)
-	{
-		MyEventWithArgs?.Invoke(this, new GreetingArgs(greeting, name));
-	}
+    [Test]
+    public async Task AwaitUntilEventHandlerEventWithArgs()
+    {
+        // Developers may await in tests for an Event with EventArgs..
+        // ..by changing the Test Method signature to async task and..
+        // ..awaiting UntilEvent passing in the Event sender, the event..
+        // ..handle and a time limit.
+        // Note: Currently WAT only handles Event handles that take the..
+        // ..the sender and an optional EventArg Object.
+        CallDeferred(nameof(InvokeEventHandlerEventWithEventArgs), "Hello", "Alex");
 
-	public class GreetingArgs : EventArgs
-	{
-		public string Greeting { get; set; }
-		public string Name { get; set; }
+        // Developers may investigate TestEventData object returned by UntilEvent..
+        // ..which containers the property Sender and the property Arguments which..
+        // ..stores the EventArg object that may have been sent.
+        TestEventData data =
+            await UntilEventHandlerEvent(this, nameof(MyEventHandlerEventWithArgs), 0.2f);
+        GreetingArgs args = (GreetingArgs)data.Arguments;
+        Assert.IsEqual(args.Greeting, "Hello");
+        Assert.IsEqual(args.Name, "Alex");
+    }
 
-		public GreetingArgs(string greeting, string name)
-		{
-			Greeting = greeting;
-			Name = name;
-		}
-		
-	}
+    [Test]
+    public async Task AwaitUntilEventWithArgs()
+    {
+        // Developers may await in tests for an Event with any parameters.
+        CallDeferred(nameof(InvokeActionEventWithArgs), "heyo", 20);
+
+        // Developers may investigate the parameters invoked by the event.
+        // These parameters are returned from UntilEvent.
+        var args = await UntilEvent(this, nameof(MyActionEventWithArgs), 10, (string text, int number) =>
+        {
+            // Developers may also use a callback method to
+            // directly link themselves up to the event.
+            Assert.IsEqual(text, "heyo");
+            Assert.IsEqual(number, 20);
+        });
+
+        Assert.IsEqual(args[0], "heyo");
+        Assert.IsEqual(args[1], 20);
+    }
+
+    private void InvokeActionEventWithNoArgs()
+    {
+        MyActionEvent?.Invoke();
+    }
+
+    private void InvokeActionEventWithArgs(string text, int number)
+    {
+        MyActionEventWithArgs?.Invoke(text, number);
+    }
+
+    private void InvokeEventHandlerEventWithNoArgs()
+    {
+        MyEventHandlerEvent?.Invoke(this, null);
+    }
+
+    private void InvokeEventHandlerEventWithEventArgs(string greeting, string name)
+    {
+        MyEventHandlerEventWithArgs?.Invoke(this, new GreetingArgs(greeting, name));
+    }
+
+    public class GreetingArgs : EventArgs
+    {
+        public string Greeting { get; set; }
+        public string Name { get; set; }
+
+        public GreetingArgs(string greeting, string name)
+        {
+            Greeting = greeting;
+            Name = name;
+        }
+
+    }
 }

--- a/tests/results.xml
+++ b/tests/results.xml
@@ -1,127 +1,38 @@
 <?xml version="1.0" ?>
-<testsuites failures="0" name="TestXML" tests="54" time="29.317">
-	<testsuite name="Assert That" failures="0"  tests="2" time="0">
-		<testcase name=" auto pass" time="0"></testcase>
-		<testcase name=" assert that" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given an Equality Assertion" failures="0"  tests="8" time="0">
-		<testcase name="When callign asserts.is_not_equal(5, 6)" time="0"></testcase>
-		<testcase name="When calling asserts.is_equal_approx_(1, 0.999999)" time="0"></testcase>
-		<testcase name="When calling asserts.is_equal_or_greater_than(2, 1)" time="0"></testcase>
-		<testcase name="When calling asserts.is_greater_than(2, 1)" time="0"></testcase>
-		<testcase name="When calling asserts.is_less_than(2, 1)" time="0"></testcase>
-		<testcase name="When calling asserts.is_equal_or_greater_than(1, 1)" time="0"></testcase>
-		<testcase name="When calling asserts.is_equal_or_less_than(1, 1)" time="0"></testcase>
-		<testcase name="When calling asserts.is_equal(1, 1)" time="0"></testcase>
-	</testsuite>
-
+<testsuites failures="0" name="TestXML" tests="55" time="13.766">
 	<testsuite name="Given A File Assertion" failures="0"  tests="3" time="0">
-		<testcase name="When calling asserts.file_does_not_exist when there is no file" time="0"></testcase>
 		<testcase name="When calling asserts file does not exist when path is empty" time="0"></testcase>
+		<testcase name="When calling asserts.file_does_not_exist when there is no file" time="0"></testcase>
 		<testcase name="When calling asserts.file_exists when the file is this suite" time="0"></testcase>
 	</testsuite>
 
-	<testsuite name="Given A Folder Assertion" failures="0"  tests="3" time="0">
-		<testcase name="When calling asserts.folder_does_not_exist when there is no folder" time="0"></testcase>
-		<testcase name="When calling asserts folder does not exist when path is empty" time="0"></testcase>
-		<testcase name="When calling asserts.folder_exists when the folder is this suite" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Has" failures="0"  tests="5" time="0">
-		<testcase name=" dict does not have key" time="0"></testcase>
-		<testcase name=" array has value" time="0"></testcase>
-		<testcase name=" dict does not have value" time="0"></testcase>
-		<testcase name=" dict has key" time="0"></testcase>
-		<testcase name=" array does not have value" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given an Is Instance of class/type Assertion" failures="0"  tests="26" time="0">
-		<testcase name="When calling asserts.is_basis(basis: Basis" time="0"></testcase>
-		<testcase name="When calling is asserts.object(node: Node)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Dictionary({})" time="0"></testcase>
-		<testcase name="When calling asserts.is_PoolColorArray(colors: PoolColorArray)" time="0"></testcase>
-		<testcase name="When calling asserts.is_PoolIntArray(ints: PoolIntArray)" time="0"></testcase>
-		<testcase name="When calling is asserts.is_PoolVector2Array(vec2s: PoolVector2Array)" time="0"></testcase>
-		<testcase name="When callign asserts.is_int(1)" time="0"></testcase>
-		<testcase name="When calling asserts.is_NodePath(@'Parent/Child')" time="0"></testcase>
-		<testcase name="When calling asserts.is_float(1.0)" time="0"></testcase>
-		<testcase name="When calling is asserts.is_PoolStringArray(strs: PoolStringArray)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Array(array: Array)" time="0"></testcase>
-		<testcase name="When calling asserts.is_color(color: Color)" time="0"></testcase>
-		<testcase name="When calling asserts.is_bool(true)" time="0"></testcase>
-		<testcase name="When calling asserts.is_PoolByteArray(bytes: PoolByteArray)" time="0"></testcase>
-		<testcase name="When calling asserts.is_AABB(aabb: AABB)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Plane(plane: Plane())" time="0"></testcase>
-		<testcase name="When calling is asserts.is_PoolRealArray(reals: PoolRealArray)" time="0"></testcase>
-		<testcase name="When calling asserts.is_string(strs: String)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Transform(transform: Transform)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Transform(transform2D: Transform2D)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Quat(quat: Quat)" time="0"></testcase>
-		<testcase name="When calling is asserts.is_PoolVector3Array(vec3s: PoolVector3Array)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Rect2(rect2: Rect2)" time="0"></testcase>
-		<testcase name="When calling asserts.is_RID(rid: RID)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Vector3(vec3: Vector3" time="0"></testcase>
-		<testcase name="When calling asserts.is_Vector2(vec2)" time="0"></testcase>
-	</testsuite>
-
 	<testsuite name="Given an Is Not Instance of class/type Assertion" failures="0"  tests="26" time="0">
-		<testcase name="when calling asserts.is_not_Basis(null)" time="0"></testcase>
 		<testcase name="when calling asserts.is_not_Array(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Color(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Dictionary(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_bool(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_AABB(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_float(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_int(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_PoolColorArray(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_PoolVector2Array(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Transform2D(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Object(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_RID(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_PoolRealArray(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Quat(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Basis(null)" time="0"></testcase>
 		<testcase name="when calling asserts.is_not_PoolIntArray(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Plane(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Rect2(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_PoolVector3Array(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_String(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Transform(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Vector3(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Vector2(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_PoolByteArray(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_PoolColorArray(null)" time="0"></testcase>
 		<testcase name="when calling asserts.is_not_PoolStringArray(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Transform2D(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Rect2(null)" time="0"></testcase>
 		<testcase name="when calling asserts.is_not_NodePath(null)" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a Null Assertion" failures="0"  tests="4" time="0">
-		<testcase name="When calling asserts.is_null(null)" time="0"></testcase>
-		<testcase name="When calling asserts.is_not_valid_instance(freed node)" time="0"></testcase>
-		<testcase name="When calling is_instance_valid(node)" time="0"></testcase>
-		<testcase name="When calling Node is not null" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given an Object Assertion" failures="0"  tests="15" time="0">
-		<testcase name="When calling asserts.object_is_not_for_queued_deletion after not calling queue free()" time="0"></testcase>
-		<testcase name="When calling asserts.is_freed(freed_object" time="0"></testcase>
-		<testcase name="When calling asserts.object_has_meta with real key but null val" time="0"></testcase>
-		<testcase name="When calling does not have user signal with class signal" time="0"></testcase>
-		<testcase name="When calling asserts.is_not_freed(unfreed_object)" time="0"></testcase>
-		<testcase name="When calling obj_does_not_have_user_signal with fake signal" time="0"></testcase>
-		<testcase name="When calling asserts.object_is_queued for deletion after calling queue_free" time="0"></testcase>
-		<testcase name="When calling asserts object is not connected with an invalid connection" time="0"></testcase>
-		<testcase name="When calling obj_has_user_signal after adding a signal" time="0"></testcase>
-		<testcase name="When calling is not blocking signals while not blocking signals" time="0"></testcase>
-		<testcase name="When calling asserts.object_does_not_have_meta()" time="0"></testcase>
-		<testcase name="When calling has_method('title')" time="0"></testcase>
-		<testcase name="When calling asserts object is connected with a valid connection" time="0"></testcase>
-		<testcase name="When calling is blocking signals while blocking signals" time="0"></testcase>
-		<testcase name="When calling asserts.object_has_meta() after adding metadata" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given the Addition Operator" failures="0"  tests="2" time="0">
-		<testcase name="When we add 7 to 6 we get 13" time="0"></testcase>
-		<testcase name="When we subtract 7 from 6 we get 1" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_float(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Vector3(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_bool(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Plane(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_RID(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_String(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Object(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_PoolVector2Array(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Quat(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_PoolRealArray(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Dictionary(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Vector2(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_AABB(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_int(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Color(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Transform(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_PoolByteArray(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_PoolVector3Array(null)" time="0"></testcase>
 	</testsuite>
 
 	<testsuite name="Given A Range Assertion" failures="0"  tests="2" time="0">
@@ -129,140 +40,30 @@
 		<testcase name="When calling is (10) not in range (in range(0, 10)" time="0"></testcase>
 	</testsuite>
 
-	<testsuite name="Given a String Assertion" failures="0"  tests="6" time="0">
-		<testcase name="When calling asserts.string_does_not_begin_with('lorem', 'impsum')" time="0"></testcase>
-		<testcase name="When calling asserts.string_ends_with('impsum', 'lorem impsum')" time="0"></testcase>
-		<testcase name="When calling asserts.string_begins_with('lorem', 'lorem impsum')" time="0"></testcase>
-		<testcase name="When calling asserts.string_contains('em im', 'lorem impsum')" time="0"></testcase>
-		<testcase name="When calling asserts.string_does_not_contain('em im', 'impsum')" time="0"></testcase>
-		<testcase name="When calling asserts.string_does_not_end_with('lorem', 'impsum')" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Supersimple" failures="0"  tests="1" time="0">
-		<testcase name=" simple" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a Test Script" failures="0"  tests="3" time="0">
-		<testcase name="When we record properties" time="0"></testcase>
-		<testcase name=" when we omit context we can see expected and got under method" time="0"></testcase>
-		<testcase name=" we can omit describe" time="0"></testcase>
-	</testsuite>
-
 	<testsuite name="FileSystemTest" failures="0"  tests="1" time="0">
-		<testcase name="Uncompiled C# not extending WAT.Test excluded" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="AwaitTest" failures="0"  tests="4" time="0">
-		<testcase name="AwaitUntilTimeout" time="0"></testcase>
-		<testcase name="AwaitUntilSignal" time="0"></testcase>
-		<testcase name="AwaitUntilEvent" time="0"></testcase>
-		<testcase name="AwaitUntilEventWithArgs" time="0"></testcase>
+		<testcase name="Uncompiled C# script using WAT; extending Test included" time="0"></testcase>
 	</testsuite>
 
 	<testsuite name="My Example Test" failures="0"  tests="2" time="0">
-		<testcase name="This Is My Simple Test" time="0"></testcase>
-		<testcase name="MyParameterizedTest" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="WatchSignalsTest" failures="0"  tests="4" time="0">
-		<testcase name="SignalWasEmitted" time="0"></testcase>
-		<testcase name="SignalWasNotEmitted" time="0"></testcase>
-		<testcase name="SignalWasEmittedXTimes" time="0"></testcase>
-		<testcase name="SignalWasEmittedWithArguments" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="My Example Test" failures="0"  tests="2" time="0">
-		<testcase name=" parameterized example" time="0"></testcase>
 		<testcase name="My Example Test Method" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Watch Signals" failures="0"  tests="4" time="0">
-		<testcase name=" signal was emitted with arguments" time="0"></testcase>
-		<testcase name=" signal was emitted" time="0"></testcase>
-		<testcase name=" signal was not emitted" time="0"></testcase>
-		<testcase name=" signal was emitted x times" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Create Scene Director" failures="0"  tests="2" time="0">
-		<testcase name=" create a test scene director from packed scene" time="0"></testcase>
-		<testcase name=" create a test scene director from string path" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Create Scene Doubles" failures="0"  tests="2" time="0">
-		<testcase name=" can stub methods of scene double children" time="0"></testcase>
-		<testcase name=" create test double scene instance" time="0"></testcase>
+		<testcase name=" parameterized example" time="0"></testcase>
 	</testsuite>
 
 	<testsuite name="Create Script Director" failures="0"  tests="7" time="0">
-		<testcase name=" create a test script director from an inner class" time="0"></testcase>
-		<testcase name=" create a test script director from string path" time="0"></testcase>
-		<testcase name=" create a test script director from loaded class" time="0"></testcase>
-		<testcase name=" create a test script director from a nested inner class" time="0"></testcase>
 		<testcase name=" create a test script director with constructor dependecies" time="0"></testcase>
-		<testcase name=" create a test script director from user defined class name" time="0"></testcase>
 		<testcase name=" create a test script director from builtin class name" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Create Script Doubles" failures="0"  tests="2" time="0">
-		<testcase name=" doubled object is instance of base class" time="0"></testcase>
-		<testcase name=" stubbed method returns stubbed value" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Use Method Director" failures="0"  tests="11" time="0">
-		<testcase name=" subcall via funcref" time="0"></testcase>
-		<testcase name=" subcall via object" time="0"></testcase>
-		<testcase name=" stub methods with return value based on param values" time="0"></testcase>
-		<testcase name=" doubled methods call implementation instead of null" time="0"></testcase>
-		<testcase name=" doubled methods was called" time="0"></testcase>
-		<testcase name=" doubled method was not called" time="0"></testcase>
-		<testcase name=" doubled methods was called with arguments" time="0"></testcase>
-		<testcase name=" doubled methods return null by default" time="0"></testcase>
-		<testcase name=" doubled methods was called with partial argument" time="0"></testcase>
-		<testcase name=" stub methods with return value" time="0"></testcase>
-		<testcase name=" stub methods with return value based on partial param values" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Params" failures="0"  tests="1" time="0">
-		<testcase name=" simple" time="0"></testcase>
+		<testcase name=" create a test script director from an inner class" time="0"></testcase>
+		<testcase name=" create a test script director from loaded class" time="0"></testcase>
+		<testcase name=" create a test script director from string path" time="0"></testcase>
+		<testcase name=" create a test script director from user defined class name" time="0"></testcase>
+		<testcase name=" create a test script director from a nested inner class" time="0"></testcase>
 	</testsuite>
 
 	<testsuite name="Given a Signal Watcher" failures="0"  tests="4" time="0">
-		<testcase name="When we watch and signal and emit it multiple times" time="0"></testcase>
-		<testcase name="When we watch a signal from an object with no bound variables" time="0"></testcase>
 		<testcase name="When we watch and emit a signal" time="0"></testcase>
 		<testcase name="When we watch and do not emit a signal" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Default Args" failures="0"  tests="1" time="0">
-		<testcase name=" default arguments of interpolate property" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a Test Double" failures="0"  tests="19" time="0">
-		<testcase name="When we call a method that we stubbed to call its super implementation by default" time="0"></testcase>
-		<testcase name="When we double an inner class" time="0"></testcase>
-		<testcase name="When we stub a method of a doubled inner class" time="0"></testcase>
-		<testcase name="When we pass in dependecies on direct" time="0"></testcase>
-		<testcase name="When we call a method that we have stubbed to return true" time="0"></testcase>
-		<testcase name="When we call a method that we are spying on" time="0"></testcase>
-		<testcase name="When we pass a funcref as a subcall" time="0"></testcase>
-		<testcase name="When we pass a funcref as a subcall that returns" time="0"></testcase>
-		<testcase name="When we stubbed a keyworded method by passing in the correct keyword" time="0"></testcase>
-		<testcase name="When we call a method that we have stubbed to return a node" time="0"></testcase>
-		<testcase name="When we pass an Object with a call_func function" time="0"></testcase>
-		<testcase name="When we call an add(x, y) method that we haven't directed" time="0"></testcase>
-		<testcase name="When we call a method that was stubbed with a partial (ie using any()) argument pattern" time="0"></testcase>
-		<testcase name="When we pass in dependecies on double" time="0"></testcase>
-		<testcase name="When we call a method that we have dummied" time="0"></testcase>
-		<testcase name="When we call a method that was stubbed with an argument pattern that includes a non-primitive object" time="0"></testcase>
-		<testcase name="When we call a method that was stubbed to return different values based on argument patterns" time="0"></testcase>
-		<testcase name="When we add an doubled inner class to it" time="0"></testcase>
-		<testcase name="When we pass arguments to a method call that we are spying on" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given is_on_floor" failures="0"  tests="3" time="0">
-		<testcase name="From a user-defined script" time="0"></testcase>
-		<testcase name="From a built-in KinematicBody2D2" time="0"></testcase>
-		<testcase name="From a child node of a scene without scripts" time="0"></testcase>
+		<testcase name="When we watch a signal from an object with no bound variables" time="0"></testcase>
+		<testcase name="When we watch and signal and emit it multiple times" time="0"></testcase>
 	</testsuite>
 
 	<testsuite name="Property Member Test" failures="0"  tests="2" time="0">
@@ -270,41 +71,8 @@
 		<testcase name="When we double a scene via path with exported values" time="0"></testcase>
 	</testsuite>
 
-	<testsuite name="Resourcex" failures="0"  tests="1" time="0">
-		<testcase name=" deleted resource has no res path" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a Scene Director" failures="0"  tests="5" time="0">
-		<testcase name="When we create two of it for the same scene" time="0"></testcase>
-		<testcase name="When we add it to the tree it runs" time="0"></testcase>
-		<testcase name="When we call a method from the root node that we stubbed" time="0"></testcase>
-		<testcase name="When we call a method from a grandchild node that we stubbed" time="0"></testcase>
-		<testcase name="When we call a method from a child node that we stubbed" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a Script Director" failures="0"  tests="4" time="0">
-		<testcase name=" from name" time="0"></testcase>
-		<testcase name="When we double an inner class" time="0"></testcase>
-		<testcase name="When we call the double the second time" time="0"></testcase>
-		<testcase name="When we create two of it for the same script" time="0"></testcase>
-	</testsuite>
-
 	<testsuite name="AttributeTest" failures="0"  tests="1" time="0">
 		<testcase name="SimpleTest" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="AttributeYieldTest" failures="0"  tests="1" time="0">
-		<testcase name="SimpleTest" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="BasicCSharpTest" failures="0"  tests="2" time="0">
-		<testcase name="CSharpTestsWorking" time="0"></testcase>
-		<testcase name="CSXharpTestsWorking" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given A Boolean Assertion" failures="0"  tests="2" time="0">
-		<testcase name="A Tautology" time="0"></testcase>
-		<testcase name="FalseIsFalse" time="0"></testcase>
 	</testsuite>
 
 	<testsuite name="ExceptionTests" failures="0"  tests="5" time="0">
@@ -315,26 +83,114 @@
 		<testcase name="AnExceptionOfTypeWasNotThrown" time="0"></testcase>
 	</testsuite>
 
-	<testsuite name="Is Instance ( class / type ) Assertions" failures="0"  tests="19" time="0">
-		<testcase name="IsAABB" time="0"></testcase>
-		<testcase name="IsArray" time="0"></testcase>
-		<testcase name="IsBasis" time="0"></testcase>
-		<testcase name="IsBool" time="0"></testcase>
-		<testcase name="IsColor" time="0"></testcase>
-		<testcase name="IsDictionary" time="0"></testcase>
-		<testcase name="IsFloat" time="0"></testcase>
-		<testcase name="IsInt" time="0"></testcase>
-		<testcase name="IsNodePath" time="0"></testcase>
-		<testcase name="IsObject" time="0"></testcase>
-		<testcase name="IsPlane" time="0"></testcase>
-		<testcase name="IsQuat" time="0"></testcase>
-		<testcase name="IsRect2" time="0"></testcase>
-		<testcase name="IsRid" time="0"></testcase>
-		<testcase name="IsString" time="0"></testcase>
-		<testcase name="IsTransform" time="0"></testcase>
-		<testcase name="IsTransform2D" time="0"></testcase>
-		<testcase name="IsVector2" time="0"></testcase>
-		<testcase name="IsVector3" time="0"></testcase>
+	<testsuite name="NullChecksTest" failures="0"  tests="2" time="0">
+		<testcase name="NullChecks" time="0"></testcase>
+		<testcase name="NullChecks2" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="SimpleTest" failures="0"  tests="1" time="0">
+		<testcase name="IsTrue" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given A Signal Watcher" failures="0"  tests="4" time="0">
+		<testcase name="WhenWeWatchASignalFromAnObjectWithNoBoundVariables" time="0"></testcase>
+		<testcase name="When we watch and emit a signal xxx" time="0"></testcase>
+		<testcase name="When we watch and do not emit a signal xxxx" time="0"></testcase>
+		<testcase name="WhenWeWatchASignalAndEmitItMultipleTimes" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Assert That" failures="0"  tests="2" time="0">
+		<testcase name=" auto pass" time="0"></testcase>
+		<testcase name=" assert that" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Has" failures="0"  tests="5" time="0">
+		<testcase name=" array has value" time="0"></testcase>
+		<testcase name=" dict does not have value" time="0"></testcase>
+		<testcase name=" dict has key" time="0"></testcase>
+		<testcase name=" dict does not have key" time="0"></testcase>
+		<testcase name=" array does not have value" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given an Object Assertion" failures="0"  tests="15" time="0">
+		<testcase name="When calling has_method('title')" time="0"></testcase>
+		<testcase name="When calling asserts.object_does_not_have_meta()" time="0"></testcase>
+		<testcase name="When calling is not blocking signals while not blocking signals" time="0"></testcase>
+		<testcase name="When calling asserts.object_has_meta with real key but null val" time="0"></testcase>
+		<testcase name="When calling asserts.is_not_freed(unfreed_object)" time="0"></testcase>
+		<testcase name="When calling asserts.object_is_queued for deletion after calling queue_free" time="0"></testcase>
+		<testcase name="When calling asserts object is connected with a valid connection" time="0"></testcase>
+		<testcase name="When calling asserts object is not connected with an invalid connection" time="0"></testcase>
+		<testcase name="When calling asserts.object_has_meta() after adding metadata" time="0"></testcase>
+		<testcase name="When calling does not have user signal with class signal" time="0"></testcase>
+		<testcase name="When calling obj_does_not_have_user_signal with fake signal" time="0"></testcase>
+		<testcase name="When calling asserts.object_is_not_for_queued_deletion after not calling queue free()" time="0"></testcase>
+		<testcase name="When calling obj_has_user_signal after adding a signal" time="0"></testcase>
+		<testcase name="When calling is blocking signals while blocking signals" time="0"></testcase>
+		<testcase name="When calling asserts.is_freed(freed_object" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Supersimple" failures="0"  tests="1" time="0">
+		<testcase name=" simple" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="My Example Test" failures="0"  tests="2" time="0">
+		<testcase name="This Is My Simple Test" time="0"></testcase>
+		<testcase name="MyParameterizedTest" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Create Scene Director" failures="0"  tests="2" time="0">
+		<testcase name=" create a test scene director from packed scene" time="0"></testcase>
+		<testcase name=" create a test scene director from string path" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Use Method Director" failures="0"  tests="11" time="0">
+		<testcase name=" subcall via funcref" time="0"></testcase>
+		<testcase name=" doubled methods return null by default" time="0"></testcase>
+		<testcase name=" doubled methods was called with arguments" time="0"></testcase>
+		<testcase name=" subcall via object" time="0"></testcase>
+		<testcase name=" doubled method was not called" time="0"></testcase>
+		<testcase name=" stub methods with return value based on param values" time="0"></testcase>
+		<testcase name=" stub methods with return value" time="0"></testcase>
+		<testcase name=" doubled methods call implementation instead of null" time="0"></testcase>
+		<testcase name=" doubled methods was called with partial argument" time="0"></testcase>
+		<testcase name=" stub methods with return value based on partial param values" time="0"></testcase>
+		<testcase name=" doubled methods was called" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a Test Double" failures="0"  tests="19" time="0">
+		<testcase name="When we pass a funcref as a subcall that returns" time="0"></testcase>
+		<testcase name="When we pass arguments to a method call that we are spying on" time="0"></testcase>
+		<testcase name="When we call a method that was stubbed with an argument pattern that includes a non-primitive object" time="0"></testcase>
+		<testcase name="When we pass in dependecies on direct" time="0"></testcase>
+		<testcase name="When we call a method that we have dummied" time="0"></testcase>
+		<testcase name="When we stub a method of a doubled inner class" time="0"></testcase>
+		<testcase name="When we pass an Object with a call_func function" time="0"></testcase>
+		<testcase name="When we add an doubled inner class to it" time="0"></testcase>
+		<testcase name="When we call a method that we stubbed to call its super implementation by default" time="0"></testcase>
+		<testcase name="When we pass a funcref as a subcall" time="0"></testcase>
+		<testcase name="When we stubbed a keyworded method by passing in the correct keyword" time="0"></testcase>
+		<testcase name="When we call a method that we have stubbed to return true" time="0"></testcase>
+		<testcase name="When we call a method that was stubbed with a partial (ie using any()) argument pattern" time="0"></testcase>
+		<testcase name="When we double an inner class" time="0"></testcase>
+		<testcase name="When we pass in dependecies on double" time="0"></testcase>
+		<testcase name="When we call a method that we have stubbed to return a node" time="0"></testcase>
+		<testcase name="When we call an add(x, y) method that we haven't directed" time="0"></testcase>
+		<testcase name="When we call a method that we are spying on" time="0"></testcase>
+		<testcase name="When we call a method that was stubbed to return different values based on argument patterns" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a Scene Director" failures="0"  tests="5" time="0">
+		<testcase name="When we add it to the tree it runs" time="0"></testcase>
+		<testcase name="When we create two of it for the same scene" time="0"></testcase>
+		<testcase name="When we call a method from the root node that we stubbed" time="0"></testcase>
+		<testcase name="When we call a method from a child node that we stubbed" time="0"></testcase>
+		<testcase name="When we call a method from a grandchild node that we stubbed" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="BasicCSharpTest" failures="0"  tests="2" time="0">
+		<testcase name="CSharpTestsWorking" time="0"></testcase>
+		<testcase name="CSXharpTestsWorking" time="0"></testcase>
 	</testsuite>
 
 	<testsuite name="IsNotInstanceTest" failures="0"  tests="19" time="0">
@@ -359,13 +215,222 @@
 		<testcase name="IsNotVector3" time="0"></testcase>
 	</testsuite>
 
+	<testsuite name="Range Assertions" failures="0"  tests="2" time="0">
+		<testcase name="WhenCallingIsInRange" time="0"></testcase>
+		<testcase name="WhenCallingIsNotInRange" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="UntilEvent" failures="0"  tests="6" time="0">
+		<testcase name="EventReached" time="0"></testcase>
+		<testcase name="EventTimedOut" time="0"></testcase>
+		<testcase name="EventWithArgsReached" time="0"></testcase>
+		<testcase name="EventWithArgsTimedOut" time="0"></testcase>
+		<testcase name="EventWithCustomArgsReached" time="0"></testcase>
+		<testcase name="EventWithCustomArgsTimedOut" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Yield" failures="0"  tests="2" time="0">
+		<testcase name=" yield until timeout" time="0"></testcase>
+		<testcase name=" yield until signal" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given an Equality Assertion" failures="0"  tests="8" time="0">
+		<testcase name="When calling asserts.is_greater_than(2, 1)" time="0"></testcase>
+		<testcase name="When calling asserts.is_equal_approx_(1, 0.999999)" time="0"></testcase>
+		<testcase name="When calling asserts.is_equal(1, 1)" time="0"></testcase>
+		<testcase name="When callign asserts.is_not_equal(5, 6)" time="0"></testcase>
+		<testcase name="When calling asserts.is_equal_or_greater_than(2, 1)" time="0"></testcase>
+		<testcase name="When calling asserts.is_less_than(2, 1)" time="0"></testcase>
+		<testcase name="When calling asserts.is_equal_or_less_than(1, 1)" time="0"></testcase>
+		<testcase name="When calling asserts.is_equal_or_greater_than(1, 1)" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given an Is Instance of class/type Assertion" failures="0"  tests="26" time="0">
+		<testcase name="When calling asserts.is_string(strs: String)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Vector2(vec2)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Vector3(vec3: Vector3" time="0"></testcase>
+		<testcase name="When calling is asserts.is_PoolVector3Array(vec3s: PoolVector3Array)" time="0"></testcase>
+		<testcase name="When calling asserts.is_bool(true)" time="0"></testcase>
+		<testcase name="When calling is asserts.object(node: Node)" time="0"></testcase>
+		<testcase name="When calling asserts.is_PoolColorArray(colors: PoolColorArray)" time="0"></testcase>
+		<testcase name="When calling asserts.is_AABB(aabb: AABB)" time="0"></testcase>
+		<testcase name="When calling asserts.is_color(color: Color)" time="0"></testcase>
+		<testcase name="When calling asserts.is_basis(basis: Basis" time="0"></testcase>
+		<testcase name="When calling asserts.is_PoolIntArray(ints: PoolIntArray)" time="0"></testcase>
+		<testcase name="When calling asserts.is_PoolByteArray(bytes: PoolByteArray)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Plane(plane: Plane())" time="0"></testcase>
+		<testcase name="When calling asserts.is_Quat(quat: Quat)" time="0"></testcase>
+		<testcase name="When calling is asserts.is_PoolRealArray(reals: PoolRealArray)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Rect2(rect2: Rect2)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Array(array: Array)" time="0"></testcase>
+		<testcase name="When calling asserts.is_NodePath(@'Parent/Child')" time="0"></testcase>
+		<testcase name="When calling asserts.is_Transform(transform2D: Transform2D)" time="0"></testcase>
+		<testcase name="When callign asserts.is_int(1)" time="0"></testcase>
+		<testcase name="When calling asserts.is_RID(rid: RID)" time="0"></testcase>
+		<testcase name="When calling is asserts.is_PoolStringArray(strs: PoolStringArray)" time="0"></testcase>
+		<testcase name="When calling is asserts.is_PoolVector2Array(vec2s: PoolVector2Array)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Transform(transform: Transform)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Dictionary({})" time="0"></testcase>
+		<testcase name="When calling asserts.is_float(1.0)" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given the Addition Operator" failures="0"  tests="2" time="0">
+		<testcase name="When we subtract 7 from 6 we get 1" time="0"></testcase>
+		<testcase name="When we add 7 to 6 we get 13" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a Test Script" failures="0"  tests="3" time="0">
+		<testcase name="When we record properties" time="0"></testcase>
+		<testcase name=" when we omit context we can see expected and got under method" time="0"></testcase>
+		<testcase name=" we can omit describe" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="WatchSignalsTest" failures="0"  tests="4" time="0">
+		<testcase name="SignalWasEmitted" time="0"></testcase>
+		<testcase name="SignalWasNotEmitted" time="0"></testcase>
+		<testcase name="SignalWasEmittedXTimes" time="0"></testcase>
+		<testcase name="SignalWasEmittedWithArguments" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Create Scene Doubles" failures="0"  tests="2" time="0">
+		<testcase name=" can stub methods of scene double children" time="0"></testcase>
+		<testcase name=" create test double scene instance" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Params" failures="0"  tests="1" time="0">
+		<testcase name=" simple" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given is_on_floor" failures="0"  tests="3" time="0">
+		<testcase name="From a child node of a scene without scripts" time="0"></testcase>
+		<testcase name="From a user-defined script" time="0"></testcase>
+		<testcase name="From a built-in KinematicBody2D2" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a Script Director" failures="0"  tests="4" time="0">
+		<testcase name="When we double an inner class" time="0"></testcase>
+		<testcase name="When we call the double the second time" time="0"></testcase>
+		<testcase name=" from name" time="0"></testcase>
+		<testcase name="When we create two of it for the same script" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given A Boolean Assertion" failures="0"  tests="2" time="0">
+		<testcase name="A Tautology" time="0"></testcase>
+		<testcase name="FalseIsFalse" time="0"></testcase>
+	</testsuite>
+
 	<testsuite name="MyTest" failures="0"  tests="1" time="0">
 		<testcase name="AutoPass" time="0"></testcase>
 	</testsuite>
 
-	<testsuite name="NullChecksTest" failures="0"  tests="2" time="0">
-		<testcase name="NullChecks" time="0"></testcase>
-		<testcase name="NullChecks2" time="0"></testcase>
+	<testsuite name="RepeatTests" failures="0"  tests="3" time="0">
+		<testcase name="SimpleTest" time="0"></testcase>
+		<testcase name="AdditionTest" time="0"></testcase>
+		<testcase name="StringAttributeTest" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="UntilEventHandlerEvent" failures="0"  tests="6" time="0">
+		<testcase name="EventReached" time="0"></testcase>
+		<testcase name="EventTimedOut" time="0"></testcase>
+		<testcase name="EventWithArgsReached" time="0"></testcase>
+		<testcase name="EventWithArgsTimedOut" time="0"></testcase>
+		<testcase name="EventWithCustomArgsReached" time="0"></testcase>
+		<testcase name="EventWithCustomArgsTimedOut" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a Yield" failures="0"  tests="11" time="0">
+		<testcase name="When the yielder heres our signal" time="0"></testcase>
+		<testcase name="When we yield twice in execute" time="0"></testcase>
+		<testcase name="When we call until_timeout (with 1.0)" time="0"></testcase>
+		<testcase name="When a signal being yielded on is emitted" time="0"></testcase>
+		<testcase name="When we yield in pre thrice" time="0"></testcase>
+		<testcase name="When it is finished" time="0"></testcase>
+		<testcase name="When we yield in start twice" time="0"></testcase>
+		<testcase name="When the yielder times out on until_timeout(0.1)" time="0"></testcase>
+		<testcase name="When yield(self.yield_value()) returns" time="0"></testcase>
+		<testcase name="When we call until signal" time="0"></testcase>
+		<testcase name="When asserting against a test" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a Boolean Assertion" failures="0"  tests="2" time="0">
+		<testcase name="When calling asserts.is_true(true)" time="0"></testcase>
+		<testcase name="When calling asserts.is_false(false)" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given A Folder Assertion" failures="0"  tests="3" time="0">
+		<testcase name="When calling asserts folder does not exist when path is empty" time="0"></testcase>
+		<testcase name="When calling asserts.folder_does_not_exist when there is no folder" time="0"></testcase>
+		<testcase name="When calling asserts.folder_exists when the folder is this suite" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a Null Assertion" failures="0"  tests="4" time="0">
+		<testcase name="When calling is_instance_valid(node)" time="0"></testcase>
+		<testcase name="When calling Node is not null" time="0"></testcase>
+		<testcase name="When calling asserts.is_null(null)" time="0"></testcase>
+		<testcase name="When calling asserts.is_not_valid_instance(freed node)" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a String Assertion" failures="0"  tests="6" time="0">
+		<testcase name="When calling asserts.string_ends_with('impsum', 'lorem impsum')" time="0"></testcase>
+		<testcase name="When calling asserts.string_does_not_begin_with('lorem', 'impsum')" time="0"></testcase>
+		<testcase name="When calling asserts.string_begins_with('lorem', 'lorem impsum')" time="0"></testcase>
+		<testcase name="When calling asserts.string_contains('em im', 'lorem impsum')" time="0"></testcase>
+		<testcase name="When calling asserts.string_does_not_end_with('lorem', 'impsum')" time="0"></testcase>
+		<testcase name="When calling asserts.string_does_not_contain('em im', 'impsum')" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="AwaitTest" failures="0"  tests="5" time="0">
+		<testcase name="AwaitUntilTimeout" time="0"></testcase>
+		<testcase name="AwaitUntilSignal" time="0"></testcase>
+		<testcase name="AwaitUntilEvent" time="0"></testcase>
+		<testcase name="AwaitUntilEventHandlerEventWithArgs" time="0"></testcase>
+		<testcase name="AwaitUntilEventWithArgs" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Watch Signals" failures="0"  tests="4" time="0">
+		<testcase name=" signal was emitted x times" time="0"></testcase>
+		<testcase name=" signal was emitted with arguments" time="0"></testcase>
+		<testcase name=" signal was emitted" time="0"></testcase>
+		<testcase name=" signal was not emitted" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Create Script Doubles" failures="0"  tests="2" time="0">
+		<testcase name=" doubled object is instance of base class" time="0"></testcase>
+		<testcase name=" stubbed method returns stubbed value" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Default Args" failures="0"  tests="1" time="0">
+		<testcase name=" default arguments of interpolate property" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Resourcex" failures="0"  tests="1" time="0">
+		<testcase name=" deleted resource has no res path" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="AttributeYieldTest" failures="0"  tests="1" time="0">
+		<testcase name="SimpleTest" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Is Instance ( class / type ) Assertions" failures="0"  tests="19" time="0">
+		<testcase name="IsAABB" time="0"></testcase>
+		<testcase name="IsArray" time="0"></testcase>
+		<testcase name="IsBasis" time="0"></testcase>
+		<testcase name="IsBool" time="0"></testcase>
+		<testcase name="IsColor" time="0"></testcase>
+		<testcase name="IsDictionary" time="0"></testcase>
+		<testcase name="IsFloat" time="0"></testcase>
+		<testcase name="IsInt" time="0"></testcase>
+		<testcase name="IsNodePath" time="0"></testcase>
+		<testcase name="IsObject" time="0"></testcase>
+		<testcase name="IsPlane" time="0"></testcase>
+		<testcase name="IsQuat" time="0"></testcase>
+		<testcase name="IsRect2" time="0"></testcase>
+		<testcase name="IsRid" time="0"></testcase>
+		<testcase name="IsString" time="0"></testcase>
+		<testcase name="IsTransform" time="0"></testcase>
+		<testcase name="IsTransform2D" time="0"></testcase>
+		<testcase name="IsVector2" time="0"></testcase>
+		<testcase name="IsVector3" time="0"></testcase>
 	</testsuite>
 
 	<testsuite name="Object Assertions" failures="0"  tests="16" time="0">
@@ -387,21 +452,6 @@
 		<testcase name="IsNotBlockingSignals" time="0"></testcase>
 	</testsuite>
 
-	<testsuite name="Range Assertions" failures="0"  tests="2" time="0">
-		<testcase name="WhenCallingIsInRange" time="0"></testcase>
-		<testcase name="WhenCallingIsNotInRange" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="RepeatTests" failures="0"  tests="3" time="0">
-		<testcase name="SimpleTest" time="0"></testcase>
-		<testcase name="AdditionTest" time="0"></testcase>
-		<testcase name="StringAttributeTest" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="SimpleTest" failures="0"  tests="1" time="0">
-		<testcase name="IsTrue" time="0"></testcase>
-	</testsuite>
-
 	<testsuite name="Given A String Assertion" failures="0"  tests="6" time="0">
 		<testcase name="WhenCallingStringBeginWith" time="0"></testcase>
 		<testcase name="WhenCallingStringDoesNotBeginWith" time="0"></testcase>
@@ -409,22 +459,6 @@
 		<testcase name="WhenCallingStringDoesNotContain" time="0"></testcase>
 		<testcase name="WhenCallingStringEndsWith" time="0"></testcase>
 		<testcase name="WhenCallingStringDoesNotEndWith" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="UntilEvent" failures="0"  tests="6" time="0">
-		<testcase name="EventReached" time="0"></testcase>
-		<testcase name="EventTimedOut" time="0"></testcase>
-		<testcase name="EventWithArgsReached" time="0"></testcase>
-		<testcase name="EventWithArgsTimedOut" time="0"></testcase>
-		<testcase name="EventWithCustomArgsReached" time="0"></testcase>
-		<testcase name="EventWithCustomArgsTimedOut" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given A Signal Watcher" failures="0"  tests="4" time="0">
-		<testcase name="WhenWeWatchASignalFromAnObjectWithNoBoundVariables" time="0"></testcase>
-		<testcase name="When we watch and emit a signal xxx" time="0"></testcase>
-		<testcase name="When we watch and do not emit a signal xxxx" time="0"></testcase>
-		<testcase name="WhenWeWatchASignalAndEmitItMultipleTimes" time="0"></testcase>
 	</testsuite>
 
 	<testsuite name="Given a Yield" failures="0"  tests="10" time="0">
@@ -438,30 +472,6 @@
 		<testcase name="WhenWeCallUntilSignal" time="0"></testcase>
 		<testcase name="WhenTheYielderTimesOut" time="0"></testcase>
 		<testcase name="WhenTheYielderHearsOurSignal" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a Boolean Assertion" failures="0"  tests="2" time="0">
-		<testcase name="When calling asserts.is_false(false)" time="0"></testcase>
-		<testcase name="When calling asserts.is_true(true)" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Yield" failures="0"  tests="2" time="0">
-		<testcase name=" yield until timeout" time="0"></testcase>
-		<testcase name=" yield until signal" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a Yield" failures="0"  tests="11" time="0">
-		<testcase name="When asserting against a test" time="0"></testcase>
-		<testcase name="When the yielder times out on until_timeout(0.1)" time="0"></testcase>
-		<testcase name="When we call until_timeout (with 1.0)" time="0"></testcase>
-		<testcase name="When a signal being yielded on is emitted" time="0"></testcase>
-		<testcase name="When yield(self.yield_value()) returns" time="0"></testcase>
-		<testcase name="When we call until signal" time="0"></testcase>
-		<testcase name="When the yielder heres our signal" time="0"></testcase>
-		<testcase name="When we yield in pre thrice" time="0"></testcase>
-		<testcase name="When we yield in start twice" time="0"></testcase>
-		<testcase name="When it is finished" time="0"></testcase>
-		<testcase name="When we yield twice in execute" time="0"></testcase>
 	</testsuite>
 
 </testsuites>


### PR DESCRIPTION
I've refactored `UntilEvent` method to accept a delegate as a callback, and also return the callback parameters. This way, you're able to use `UntilEvent` for non-`EventHandler` events (Such as `Action` or your own custom delegate). I've renamed the original function to `UntilEventHandlerEvent` (it's a bit long but I can't think of anything shorter without abbreviations).