### PR TITLE
Fix DoesNotThrow() to fail if exception was thrown

### DIFF
--- a/addons/WAT/mono/assertions/Utility.cs
+++ b/addons/WAT/mono/assertions/Utility.cs
@@ -44,7 +44,7 @@ namespace WAT
 			catch (Exception e)
 			{
 				string fail = $"Threw {e} with Message: {e.Message}";
-				return Result(true, "No Exception was thrown", fail, context);
+				return Result(false, "No Exception was thrown", fail, context);
 			}
 		}
 		


### PR DESCRIPTION
I tested this change by running WAT's own tests in Godot_v3.5-stable_mono_x11_64, and then by using WAT in my own project and verifying that DoesNotThrow() fails if I throw an exception, and passes otherwise.

Thanks for making WAT. :)